### PR TITLE
Modernize game board frame and scoreboard UI

### DIFF
--- a/src/web/Jeffpardy.scss
+++ b/src/web/Jeffpardy.scss
@@ -1,5 +1,12 @@
 $colorGameBoard: #060CE9;
 $colorBrown: #2b0f01;
+$colorBoardFrame: #1a1a2e;
+$colorBoardInnerFrame: #16213e;
+$colorHostControls: #1a1a2e;
+$colorHostControlBtn: #2d6a4f;
+$colorHostControlBtnHover: #40916c;
+$colorHostControlBtnDisabled: #444;
+$colorScoreboardBg: #0f0f1a;
 
 /* Font Families */
 @font-face {
@@ -307,37 +314,41 @@ div#jeffpardyBoardFrame {
     width: 100%;
     display: flex;
     flex-grow: 1;
-    background-color: grey;
-    padding: 20px;
+    background: linear-gradient(135deg, $colorBoardFrame 0%, darken($colorBoardFrame, 5) 100%);
+    padding: 16px;
     box-sizing: border-box;
 }
 
 div#jeffpardyBoardInnerFrame {
     width: 100%;
     flex-grow: 1;
-    background-color: darkgrey;
-    padding: 5px;
+    background: linear-gradient(180deg, rgba(255,255,255,0.08) 0%, rgba(255,255,255,0.02) 100%);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 8px;
+    padding: 6px;
     box-sizing: inherit;
     min-width: 1100px;
+    box-shadow: 0 4px 30px rgba(0, 0, 0, 0.5), inset 0 1px 0 rgba(255, 255, 255, 0.05);
 }
 
 div#jeffpardyBoard {
     width: 100%;
     height: 100%;
-    background-color: black;
+    background-color: rgba(0, 0, 0, 0.6);
     display: flex;
     flex-direction: row;
     position: relative;
-    padding: 10px;
+    padding: 4px;
     box-sizing: inherit;
+    border-radius: 4px;
 }
 
 div#jeffpardyBoard div.jeffpardyBoardClues {
     display: grid;
     grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr;
     grid-template-rows: 1.5fr 1fr 1fr 1fr 1fr 1fr;
+    gap: 4px;
     width: 100%;
-
 }
 
 div#jeffpardyBoard div.jeffpardyCategory {
@@ -346,11 +357,12 @@ div#jeffpardyBoard div.jeffpardyCategory {
     background-color: $colorGameBoard;
     font-size: 2rem;
     text-align: center;
-    margin: 2px;
     padding: 10px;
     display: flex;
     align-items: center;
     justify-content: center;
+    border-radius: 4px;
+    box-shadow: inset 0 -2px 4px rgba(0, 0, 0, 0.3);
 }
 
 div#jeffpardyBoard div.jeffpardyClue {
@@ -358,28 +370,29 @@ div#jeffpardyBoard div.jeffpardyClue {
 
     display: flex;
     flex-direction: column;
-    box-sizing: inherit;
-    margin: 2px;
+    box-sizing: border-box;
     position: relative;
     font-size: 3.5rem;
-    box-sizing: inherit;
-    background-color: #060CE9;
-    box-sizing: border-box;
-
+    background-color: $colorGameBoard;
+    border-radius: 4px;
+    transition: transform 0.1s ease, box-shadow 0.15s ease;
 }
 
 div#jeffpardyBoard div.jeffpardyClue a {
     display: flex;
     flex-grow: 1;
     width: 100%;
-    color: yellow;
+    color: #FFD700;
     text-decoration: none;
     align-items: center;
     justify-content: center;
+    border-radius: 4px;
+    transition: background-color 0.15s ease;
 }
 
 div#jeffpardyBoard div.jeffpardyClue a:hover {
-    background-color: darken($colorGameBoard, 20);
+    background-color: darken($colorGameBoard, 15);
+    box-shadow: inset 0 0 20px rgba(255, 215, 0, 0.15);
 }
 
 div#jeffpardyBoard div.jeffpardyClue a:hover a.asked:hover {
@@ -839,35 +852,60 @@ button#buzzer.lockedout:active {
 }
 
 div#scoreboard {
-    height: 130px;
+    min-height: 130px;
     box-sizing: border-box;
-    background-color: $colorBrown;
+    background: linear-gradient(180deg, $colorScoreboardBg 0%, darken($colorScoreboardBg, 3) 100%);
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
     display: flex;
     flex-direction: row;
-    padding-top: 10px;
-    padding-bottom: 10px;
+    padding: 10px 10px;
+    gap: 10px;
 }
 
 div#scoreboard div#hostControls {
-    width: 250px;
-    padding-left: 10px;
+    min-width: 220px;
+    padding: 8px 12px;
     display: grid;
-    color: white;
-    font-weight: bold;
+    color: rgba(255, 255, 255, 0.85);
+    font-weight: 600;
+    font-size: 0.8rem;
     grid-template-columns: auto auto;
-    grid-template-rows: auto auto 1fr;
+    grid-template-rows: auto auto auto auto;
     row-gap: 4px;
+    column-gap: 8px;
+    align-items: center;
+    background: rgba(255, 255, 255, 0.04);
+    border-radius: 8px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 div#scoreboard div#hostControls button {
     margin-right: 4px;
-    background-color: green;
-    border-color: darkgreen;
+    padding: 4px 10px;
+    background-color: $colorHostControlBtn;
+    border: 1px solid darken($colorHostControlBtn, 10);
+    color: white;
+    border-radius: 4px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.15s ease, transform 0.1s ease;
+}
+
+div#scoreboard div#hostControls button:hover:not(:disabled) {
+    background-color: $colorHostControlBtnHover;
+    transform: translateY(-1px);
+}
+
+div#scoreboard div#hostControls button:active:not(:disabled) {
+    transform: translateY(0);
 }
 
 div#scoreboard div#hostControls button:disabled {
-    background-color: grey;
-    border-color: darkgrey;
+    background-color: $colorHostControlBtnDisabled;
+    border-color: darken($colorHostControlBtnDisabled, 10);
+    color: rgba(255, 255, 255, 0.35);
+    cursor: not-allowed;
 }
 
 
@@ -875,57 +913,69 @@ div#scoreboard .scoreEntries {
     display: flex;
     flex-grow: 1;
     flex-direction: row;
-    align-items: left;
+    align-items: center;
     text-align: center;
-    padding-left: 30px;
+    padding-left: 10px;
+    gap: 10px;
+    overflow-x: auto;
 }
 
 div#scoreboard .scoreboardEntry {
     @extend %jeffpardyMainFont;
 
-    width: 200px;
-    background-color: $colorGameBoard;
-    border: 2px solid black;
-    box-shadow: 0px 0px 20px rgb(50, 50, 50);
-    margin-right: 10px;
+    min-width: 180px;
+    background: linear-gradient(180deg, lighten($colorGameBoard, 5) 0%, darken($colorGameBoard, 8) 100%);
+    border: 2px solid rgba(255, 255, 255, 0.15);
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+    transition: border-color 0.3s ease, box-shadow 0.3s ease;
+    overflow: hidden;
 }
 
 
 div#scoreboard .scoreboardEntry.controllingTeam {
-    border: 2px solid yellow;
-    box-shadow: 0px 0px 20px yellow;
+    border: 2px solid #FFD700;
+    box-shadow: 0 0 15px rgba(255, 215, 0, 0.4);
 }
 
 div#scoreboard .scoreboardEntry.winningTeam {
-    border: 2px solid green;
-    box-shadow: 0px 0px 20px green;
+    border: 2px solid #4CAF50;
+    box-shadow: 0 0 15px rgba(76, 175, 80, 0.4);
 }
 
 div#scoreboard .scoreboardEntry .buzzerIndicator {
-    height: 15px;
-    background-color: black;
+    height: 4px;
+    background-color: transparent;
+    transition: background-color 0.2s ease;
 }
 
 div#scoreboard .scoreboardEntry .buzzerIndicator.buzzerActive {
-    background-color: white;
+    background-color: #FFD700;
+    box-shadow: 0 0 8px rgba(255, 215, 0, 0.6);
 }
 
 
 div#scoreboard .scoreboardEntry .buzzerIndicator.buzzedIn {
-    background-color: red;
+    background-color: #f44336;
+    box-shadow: 0 0 8px rgba(244, 67, 54, 0.6);
 }
 
 
 div#scoreboard .scoreboardEntry .teamName {
-    font-size: 2em;
-    border-bottom: solid 5px black;
+    font-size: 1.6em;
+    padding: 4px 8px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 
 div#scoreboard .scoreboardEntry .score {
-    font-size: 2.5em;
-    padding-top: 5px;
-    padding-bottom: 5px;
+    font-size: 2.2em;
+    padding: 6px 8px;
+    color: #FFD700;
+    text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
 }
 
 
@@ -1016,10 +1066,12 @@ div.topPageNormal {
     padding-top: 5px;
     height: 70px;
     color: white;
-    background-color: $colorBrown;
+    background: linear-gradient(180deg, lighten($colorBrown, 5) 0%, $colorBrown 100%);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
     display: flex;
     flex-direction: column;
     align-content: center;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
 }
 
 .topSection .title {


### PR DESCRIPTION
## Changes

### Board Frame
- Replace flat grey/darkgrey borders with dark gradient + subtle glass-effect border
- Add \order-radius\ and inset shadow for depth
- Use \gap\-based grid spacing instead of cell margins
- Rounded corners on category headers and clue cells
- Hover glow effect on clue values
- Gold (\#FFD700\) for value text instead of plain yellow

### Scoreboard & Host Controls
- Dark themed background replacing the brown bar
- Host controls panel gets a subtle card treatment (rounded border, translucent bg)
- Styled buttons: green with hover lift effect, proper disabled states
- Score cards: gradient backgrounds, rounded corners, thinner buzzer indicators with colored glow
- Gold score text with subtle shadow
- Softer glow effects for controlling/winning team highlights

### Title Bar
- Gradient background with bottom shadow for visual separation

## Before vs After
The board frame goes from flat grey borders to a sleek dark-themed frame. The scoreboard area transitions from raw HTML buttons on brown to a proper dark control panel with styled team cards.