### PR TITLE
Integrate SCSS into Vite build pipeline

### DIFF
--- a/Pages/Buzzer.cshtml
+++ b/Pages/Buzzer.cshtml
@@ -6,7 +6,7 @@
 }
 
 <head>
-    <link rel="stylesheet" href="~/css/dist/Jeffpardy.css" />
+    <link rel="stylesheet" href="~/js/dist/assets/style.css" />
 </head>
 
 <body>

--- a/Pages/Host.cshtml
+++ b/Pages/Host.cshtml
@@ -5,7 +5,7 @@
 }
 
     <head>
-        <link rel="stylesheet" href="~/css/dist/Jeffpardy.css" />
+        <link rel="stylesheet" href="~/js/dist/assets/style.css" />
         <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
         <title>Jeffpardy!</title>
     </head>

--- a/Pages/HostSecondary.cshtml
+++ b/Pages/HostSecondary.cshtml
@@ -5,7 +5,7 @@
 }
 
 <head>
-    <link rel="stylesheet" href="~/css/dist/Jeffpardy.css" />
+    <link rel="stylesheet" href="~/js/dist/assets/style.css" />
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
     <title>Jeffpardy!</title>
 </head>

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -5,7 +5,7 @@
 }
 
 <head>
-    <link rel="stylesheet" href="~/css/dist/Jeffpardy.css" />
+    <link rel="stylesheet" href="~/js/dist/assets/style.css" />
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
     <title>Jeffpardy!</title>
 </head>

--- a/Pages/Player.cshtml
+++ b/Pages/Player.cshtml
@@ -5,7 +5,7 @@
 }
 
 <head>
-    <link rel="stylesheet" href="~/css/dist/Jeffpardy.css" />
+    <link rel="stylesheet" href="~/js/dist/assets/style.css" />
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
     <title>Jeffpardy!</title>
 </head>

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "dev": "vite build --mode development --watch",
     "build": "vite build",
     "buildProd": "vite build --mode production",
-    "scss": "sass src/web:wwwroot/css/dist",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/src/web/pages/hostPage/HostPage.tsx
+++ b/src/web/pages/hostPage/HostPage.tsx
@@ -1,5 +1,6 @@
 ﻿import * as React from "react";
 import { createRoot } from 'react-dom/client';
+import "../../Jeffpardy.scss";
 import { JeffpardyHostController } from "./JeffpardyHostController";
 import { JeffpardyBoard } from "./gameBoard/JeffpardyBoard";
 import { Scoreboard } from "./scoreboard/Scoreboard";

--- a/src/web/pages/hostSecondaryPage/HostSecondaryPage.tsx
+++ b/src/web/pages/hostSecondaryPage/HostSecondaryPage.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { createRoot } from "react-dom/client";
+import "../../Jeffpardy.scss";
 import * as signalR from "@microsoft/signalr";
 import { Logger } from "../../utilities/Logger";
 import { IPlayer, TeamDictionary } from "../../Types"

--- a/src/web/pages/playerPage/PlayerPage.tsx
+++ b/src/web/pages/playerPage/PlayerPage.tsx
@@ -1,5 +1,6 @@
 ﻿import * as React from "react";
 import { createRoot } from 'react-dom/client';
+import "../../Jeffpardy.scss";
 import * as signalR from "@microsoft/signalr";
 import { Logger } from "../../utilities/Logger";
 import { IPlayer, TeamDictionary } from "../../Types"

--- a/src/web/pages/startPage/StartPage.tsx
+++ b/src/web/pages/startPage/StartPage.tsx
@@ -1,5 +1,6 @@
 ﻿import * as React from "react";
 import { createRoot } from "react-dom/client";
+import "../../Jeffpardy.scss";
 import { Attribution } from "../../components/attribution/Attribution";
 /**
  * Root page for the application, begins the rendering.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,10 +9,18 @@ export default defineConfig({
         globals: true,
         setupFiles: ['./src/web/test-setup.ts'],
     },
+    css: {
+        preprocessorOptions: {
+            scss: {
+                silenceDeprecations: ['global-builtin', 'color-functions', 'import'],
+            },
+        },
+    },
     build: {
         outDir: 'wwwroot/js/dist',
         emptyOutDir: true,
         sourcemap: true,
+        cssCodeSplit: false,
         rollupOptions: {
             input: {
                 index: path.resolve(__dirname, 'src/web/pages/startPage/StartPage.tsx'),


### PR DESCRIPTION
Closes #39

## Changes
- Import \Jeffpardy.scss\ in all 4 entry points so Vite compiles it automatically
- Configure \cssCodeSplit: false\ for a single CSS output file
- Silence deprecated Sass function warnings in Vite config
- Update all 5 Razor pages to reference Vite-generated CSS (\~/js/dist/assets/style.css\)
- Remove the separate \
pm run scss\ script — no longer needed

## Result
- **Single build command** (\
pm run build\) now produces both JS and CSS
- No more separate SCSS compilation step
- All 28 tests pass