### PR TITLE
Fix CI: remove npm run scss from csproj build

### DIFF
--- a/Jeffpardy.csproj
+++ b/Jeffpardy.csproj
@@ -20,7 +20,7 @@
     </AssemblyAttribute>
   </ItemGroup>
   <Target Name="Frontend Build" AfterTargets="Build" Condition="'$(SkipFrontendBuild)' != 'true'">
-    <Exec Condition="$(Configuration) == 'Debug'" Command="npm ci --legacy-peer-deps &amp;&amp; npm run build &amp;&amp; npm run scss" />
-    <Exec Condition="$(Configuration) == 'Release'" Command="npm ci --legacy-peer-deps &amp;&amp; npm run buildProd &amp;&amp; npm run scss" />
+    <Exec Condition="$(Configuration) == 'Debug'" Command="npm ci --legacy-peer-deps &amp;&amp; npm run build" />
+    <Exec Condition="$(Configuration) == 'Release'" Command="npm ci --legacy-peer-deps &amp;&amp; npm run buildProd" />
   </Target>
 </Project>


### PR DESCRIPTION
The SCSS integration into Vite (PR #51) removed the \scss\ script from package.json but the \.csproj\ still referenced \
pm run scss\ in its build target, causing the deploy workflow to fail.

Removes \&& npm run scss\ from both Debug and Release build commands.