### PR TITLE
Fix: add type=module to script tags

### DIFF
--- a/Pages/Buzzer.cshtml
+++ b/Pages/Buzzer.cshtml
@@ -12,4 +12,4 @@
 <body>
 </body>
 
-<script src="~/js/dist/buzzer.js"></script>
+<script type="module" src="~/js/dist/buzzer.js"></script>

--- a/Pages/Host.cshtml
+++ b/Pages/Host.cshtml
@@ -12,4 +12,4 @@
 
 <body></body>
 
-<script src="~/js/dist/host.js"></script>
+<script type="module" src="~/js/dist/host.js"></script>

--- a/Pages/HostSecondary.cshtml
+++ b/Pages/HostSecondary.cshtml
@@ -13,4 +13,4 @@
 <body>
 </body>
 
-<script src="~/js/dist/hostSecondary.js"></script>
+<script type="module" src="~/js/dist/hostSecondary.js"></script>

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -13,4 +13,4 @@
 <body>
 </body>
 
-<script src="~/js/dist/index.js"></script>
+<script type="module" src="~/js/dist/index.js"></script>

--- a/Pages/Player.cshtml
+++ b/Pages/Player.cshtml
@@ -13,4 +13,4 @@
 <body>
 </body>
 
-<script src="~/js/dist/player.js"></script>
+<script type="module" src="~/js/dist/player.js"></script>


### PR DESCRIPTION
Vite outputs ES modules. Without type=module on the script tags, browsers throw Cannot use import statement outside a module. This broke both local dev and production.