### PR TITLE
Add collapsible QR code drawer to game board

### DIFF
--- a/src/web/Jeffpardy.scss
+++ b/src/web/Jeffpardy.scss
@@ -1341,6 +1341,65 @@ div.topPageNormal {
     display: flex;
     flex-direction: column;
     height: 100%;
+    position: relative;
+}
+
+/* QR Code Drawer */
+.qrDrawer {
+    position: absolute;
+    bottom: 0;
+    right: 20px;
+    z-index: 100;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    transition: transform 0.3s ease;
+    transform: translateY(calc(100% - 30px));
+}
+
+.qrDrawer.open {
+    transform: translateY(0);
+}
+
+.qrDrawerToggle {
+    background: rgba(0, 0, 0, 0.7);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-bottom: none;
+    border-radius: 8px 8px 0 0;
+    color: rgba(255, 255, 255, 0.8);
+    cursor: pointer;
+    padding: 4px 16px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    transition: background-color 0.15s ease;
+}
+
+.qrDrawerToggle:hover {
+    background: rgba(0, 0, 0, 0.85);
+    color: white;
+}
+
+.qrDrawerContent {
+    background: rgba(0, 0, 0, 0.7);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 8px 0 0 0;
+    padding: 8px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.qrDrawerContent canvas {
+    border-radius: 4px;
+}
+
+.qrDrawerContent .qrGameCode {
+    color: white;
+    font-size: 1.1rem;
+    font-weight: 700;
+    letter-spacing: 0.15em;
+    margin-top: 4px;
 }
 
 /*   topSection container ===========================  */

--- a/src/web/pages/hostPage/HostPage.tsx
+++ b/src/web/pages/hostPage/HostPage.tsx
@@ -9,6 +9,7 @@ import { Debug, DebugFlags } from "../../utilities/Debug";
 import { HostStartScreen } from "./hostStartScreen/HostStartScreen";
 import { PlayerList } from "../../components/playerList/PlayerList";
 import { HostLobby } from "./HostLobby";
+import * as QRCode from "qrcode.react";
 import { IGameData, FinalJeffpardyAnswerDictionary, FinalJeffpardyWagerDictionary } from "./Types";
 import { ICategory, ITeam, TeamDictionary } from "../../Types";
 
@@ -32,6 +33,7 @@ export interface IHostPageState {
     gameData: IGameData;
     finalJeffpardyWagers: FinalJeffpardyWagerDictionary;
     finalJeffpardyAnswers: FinalJeffpardyAnswerDictionary;
+    isQrDrawerOpen: boolean;
 }
 
 export interface IHostPage {
@@ -83,7 +85,8 @@ export class HostPage extends React.Component<IHostPageProps, IHostPageState> {
             teams: {},
             gameData: null,
             finalJeffpardyWagers: {},
-            finalJeffpardyAnswers: {}
+            finalJeffpardyAnswers: {},
+            isQrDrawerOpen: false
         }
     }
 
@@ -316,6 +319,18 @@ export class HostPage extends React.Component<IHostPageProps, IHostPageState> {
                                         "/hostSecondary#" +
                                         this.gameCode +
                                         this.hostCode } />
+                            </div>
+                        </div>
+                        <div className={ "qrDrawer" + (this.state.isQrDrawerOpen ? " open" : "") }>
+                            <button className="qrDrawerToggle" onClick={ () => this.setState({ isQrDrawerOpen: !this.state.isQrDrawerOpen }) }>
+                                { this.state.isQrDrawerOpen ? "▼" : "▲ Join" }
+                            </button>
+                            <div className="qrDrawerContent">
+                                <QRCode.QRCodeCanvas
+                                    value={ "https://" + window.location.hostname + (window.location.port != "" ? ":" + window.location.port : "") + "/player#" + this.gameCode }
+                                    size={ 120 }
+                                    includeMargin={ true } />
+                                <div className="qrGameCode">{ this.gameCode }</div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Adds a floating QR code drawer in the bottom-right corner of the game board view, so late players can join mid-game.

- **Collapsed**: shows a small '▲ Join' tab at the bottom-right
- **Expanded**: shows QR code + game code, click '▼' to collapse
- Translucent dark background, matches existing game UI style
- Smooth slide-up/down animation

All tests pass (28 frontend, 77 backend).