### PR TITLE
Add category reveal animation at round start

### DIFF
--- a/src/web/Jeffpardy.scss
+++ b/src/web/Jeffpardy.scss
@@ -373,6 +373,46 @@ div#jeffpardyBoard {
     }
 }
 
+@keyframes categoryRevealIn {
+    from {
+        opacity: 0;
+        transform: scale(0.8);
+    }
+    to {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+
+div#jeffpardyBoard div.categoryReveal {
+    @extend %jeffpardyMainFont;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    width: 100%;
+    background-color: $colorGameBoard;
+    border-radius: 4px;
+    animation: categoryRevealIn 0.4s ease-out;
+}
+
+div#jeffpardyBoard div.categoryReveal .categoryRevealTitle {
+    font-size: 5rem;
+    color: white;
+    text-align: center;
+    text-shadow: 2px 2px 8px rgba(0, 0, 0, 0.5);
+    padding: 20px;
+}
+
+div#jeffpardyBoard div.categoryReveal .categoryRevealHint {
+    font-size: 0.9rem;
+    color: rgba(255, 255, 255, 0.4);
+    position: absolute;
+    bottom: 20px;
+    letter-spacing: 0.1em;
+}
+
 div#jeffpardyBoard div.jeffpardyBoardClues {
     display: grid;
     grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr;

--- a/src/web/pages/hostPage/gameBoard/JeffpardyBoard.tsx
+++ b/src/web/pages/hostPage/gameBoard/JeffpardyBoard.tsx
@@ -13,6 +13,7 @@ import { HostPageViewMode } from "../HostPage";
 
 export enum JeopardyBoardView {
     Board,
+    CategoryReveal,
     DailyDouble,
     Clue,
     Question,
@@ -39,6 +40,7 @@ export interface IJeffpardyBoardState {
     jeopardyBoardView: JeopardyBoardView;
     timerPercentageRemaining: number;
     finalJeffpardyTimerActive: boolean;
+    revealCategoryIndex: number;
 }
 
 export interface IJeffpardyBoard {
@@ -70,7 +72,10 @@ export class JeffpardyBoard extends React.Component<IJeffpardyBoardProps, IJeffp
         }
 
         // HACK HACK
-        let boardView: JeopardyBoardView = JeopardyBoardView.Board;
+        let boardView: JeopardyBoardView = JeopardyBoardView.CategoryReveal;
+        if (Debug.IsFlagSet(DebugFlags.SkipIntro)) {
+            boardView = JeopardyBoardView.Board;
+        }
         if (Debug.IsFlagSet(DebugFlags.FinalJeffpardy)) {
             boardView = JeopardyBoardView.Intermission;
         }
@@ -80,10 +85,38 @@ export class JeffpardyBoard extends React.Component<IJeffpardyBoardProps, IJeffp
             activeClue: null,
             activeCategory: null,
             timerPercentageRemaining: 1,
-            finalJeffpardyTimerActive: false
+            finalJeffpardyTimerActive: false,
+            revealCategoryIndex: 0
         }
 
         this.props.jeffpardyHostController.setJeffpardyBoard(this);
+    }
+
+    componentDidMount() {
+        window.addEventListener("keydown", this.handleRevealKeyDown);
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener("keydown", this.handleRevealKeyDown);
+    }
+
+    private handleRevealKeyDown = (e: KeyboardEvent) => {
+        if (this.state.jeopardyBoardView !== JeopardyBoardView.CategoryReveal) return;
+        if (e.code !== "Space") return;
+        e.preventDefault();
+        this.advanceCategoryReveal();
+    }
+
+    private advanceCategoryReveal = () => {
+        const nextIndex = this.state.revealCategoryIndex + 1;
+        if (this.props.categories && nextIndex >= this.props.categories.length) {
+            this.setState({
+                jeopardyBoardView: JeopardyBoardView.Board,
+                revealCategoryIndex: 0
+            });
+        } else {
+            this.setState({ revealCategoryIndex: nextIndex });
+        }
     }
 
     public showClue = (category: ICategory, clue: IClue) => {
@@ -141,7 +174,8 @@ export class JeffpardyBoard extends React.Component<IJeffpardyBoardProps, IJeffp
         if (this.props.round < (numRounds - 1)) {
             this.props.jeffpardyHostController.startNewRound();
             this.setState({
-                jeopardyBoardView: JeopardyBoardView.Board
+                jeopardyBoardView: JeopardyBoardView.CategoryReveal,
+                revealCategoryIndex: 0
             })
         } else {
             this.props.jeffpardyHostController.startFinalJeffpardy();
@@ -286,6 +320,14 @@ export class JeffpardyBoard extends React.Component<IJeffpardyBoardProps, IJeffp
                         { this.state.jeopardyBoardView == JeopardyBoardView.Board &&
                             <div className="jeffpardyBoardClues">
                                 { boardGridElements }
+                            </div>
+                        }
+                        { this.state.jeopardyBoardView == JeopardyBoardView.CategoryReveal && this.props.categories &&
+                            <div className="categoryReveal" key={ this.state.revealCategoryIndex }>
+                                <div className="categoryRevealTitle">
+                                    { this.props.categories[this.state.revealCategoryIndex].title }
+                                </div>
+                                <div className="categoryRevealHint">press SPACE to continue</div>
                             </div>
                         }
                         { (this.state.jeopardyBoardView == JeopardyBoardView.Clue || this.state.jeopardyBoardView == JeopardyBoardView.Question) &&


### PR DESCRIPTION
Like the TV show, categories are revealed one at a time before the board appears.

### How it works
- At each round start, categories are shown full-screen one by one
- Press **SPACE** to advance to the next category
- After the last category, the full board appears with the existing fade-in animation
- Small 'press SPACE to continue' hint at bottom of each reveal screen
- Each category animates in with a scale+fade effect

### Details
- New \CategoryReveal\ board view state with \evealCategoryIndex\ tracking
- Skipped when \SkipIntro\ debug flag is set
- Also plays at the start of round 2 (Super Jeffpardy)
- No conflict with existing SPACE key handling (Scoreboard only handles SPACE in Question state)

All tests pass (28 frontend, 77 backend).