### PR TITLE
Refactor controllers to use dependency injection

### DIFF
--- a/src/backend/AzureBlobCategoryLoader.cs
+++ b/src/backend/AzureBlobCategoryLoader.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Jeffpardy
 {
-    public class AzureBlobCategoryLoader
+    public class AzureBlobCategoryLoader : ICategoryLoader
     {
         private static readonly Lazy<AzureBlobCategoryLoader> instance = new Lazy<AzureBlobCategoryLoader>(() => new AzureBlobCategoryLoader());
 

--- a/src/backend/ICategoryLoader.cs
+++ b/src/backend/ICategoryLoader.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+
+namespace Jeffpardy
+{
+    public interface ICategoryLoader
+    {
+        Task<Category> LoadCategoryAsync(ManifestCategory manifestCategory);
+        Task<Category> LoadCategoryAsync(int season, string fileName, int index);
+    }
+}

--- a/src/backend/Jeffpardy.Tests/CategoriesControllerTests.cs
+++ b/src/backend/Jeffpardy.Tests/CategoriesControllerTests.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+
+namespace Jeffpardy.Tests
+{
+    public class CategoriesControllerTests
+    {
+        private readonly Mock<ISeasonManifestCache> _mockCache;
+        private readonly Mock<ICategoryLoader> _mockLoader;
+
+        public CategoriesControllerTests()
+        {
+            _mockCache = new Mock<ISeasonManifestCache>();
+            _mockLoader = new Mock<ICategoryLoader>();
+        }
+
+        private CategoriesController CreateController()
+        {
+            return new CategoriesController(_mockCache.Object, _mockLoader.Object);
+        }
+
+        private List<ManifestCategory> CreateManifestCategories(int count, string prefix = "Cat")
+        {
+            var list = new List<ManifestCategory>();
+            for (int i = 0; i < count; i++)
+            {
+                list.Add(new ManifestCategory
+                {
+                    Title = $"{prefix}-{i}",
+                    FileName = $"{prefix.ToLower()}{i}.json",
+                    Index = i,
+                    Season = 1,
+                    AirDate = new DateTime(2023, 1, 1)
+                });
+            }
+            return list;
+        }
+
+        [Fact]
+        public async Task GetGameData_ReturnsTwoRoundsAndFinalCategory()
+        {
+            var jeopardyCategories = CreateManifestCategories(6, "J");
+            var doubleJeopardyCategories = CreateManifestCategories(6, "DJ");
+            var finalCategories = CreateManifestCategories(1, "FJ");
+
+            _mockCache.Setup(c => c.JeopardyCategoryList).Returns(jeopardyCategories);
+            _mockCache.Setup(c => c.DoubleJeopardyCategoryList).Returns(doubleJeopardyCategories);
+            _mockCache.Setup(c => c.FinalJeopardyCategoryList).Returns(finalCategories);
+
+            _mockLoader.Setup(l => l.LoadCategoryAsync(It.IsAny<ManifestCategory>()))
+                .ReturnsAsync(new Category { Title = "Test Category" });
+
+            var controller = CreateController();
+            var result = await controller.GetGameData();
+
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Rounds.Length);
+            Assert.Equal(0, result.Rounds[0].Id);
+            Assert.Equal(1, result.Rounds[1].Id);
+            Assert.NotNull(result.FinalJeffpardyCategory);
+        }
+
+        [Fact]
+        public async Task GetGameData_LoadsSixCategoriesPerRound()
+        {
+            var jeopardyCategories = CreateManifestCategories(6, "J");
+            var doubleJeopardyCategories = CreateManifestCategories(6, "DJ");
+            var finalCategories = CreateManifestCategories(1, "FJ");
+
+            _mockCache.Setup(c => c.JeopardyCategoryList).Returns(jeopardyCategories);
+            _mockCache.Setup(c => c.DoubleJeopardyCategoryList).Returns(doubleJeopardyCategories);
+            _mockCache.Setup(c => c.FinalJeopardyCategoryList).Returns(finalCategories);
+
+            _mockLoader.Setup(l => l.LoadCategoryAsync(It.IsAny<ManifestCategory>()))
+                .ReturnsAsync(new Category { Title = "Test" });
+
+            var controller = CreateController();
+            var result = await controller.GetGameData();
+
+            Assert.Equal(6, result.Rounds[0].Categories.Length);
+            Assert.Equal(6, result.Rounds[1].Categories.Length);
+        }
+
+        [Theory]
+        [InlineData(RoundDescriptor.Jeffpardy)]
+        [InlineData(RoundDescriptor.SuperJeffpardy)]
+        [InlineData(RoundDescriptor.FinalJeffpardy)]
+        public async Task GetRandomCategory_ReturnsCategory(RoundDescriptor roundDescriptor)
+        {
+            var categories = CreateManifestCategories(3, "Cat");
+            _mockCache.Setup(c => c.JeopardyCategoryList).Returns(categories);
+            _mockCache.Setup(c => c.DoubleJeopardyCategoryList).Returns(categories);
+            _mockCache.Setup(c => c.FinalJeopardyCategoryList).Returns(categories);
+
+            var expectedCategory = new Category { Title = "Expected" };
+            _mockLoader.Setup(l => l.LoadCategoryAsync(It.IsAny<ManifestCategory>()))
+                .ReturnsAsync(expectedCategory);
+
+            var controller = CreateController();
+            var result = await controller.GetRandomCategory(roundDescriptor);
+
+            Assert.Equal("Expected", result.Title);
+        }
+
+        [Fact]
+        public async Task GetRandomCategory_UsesJeopardyCategoryList_ForJeffpardy()
+        {
+            var jeopardyCategories = CreateManifestCategories(1, "J");
+            var otherCategories = CreateManifestCategories(1, "Other");
+
+            _mockCache.Setup(c => c.JeopardyCategoryList).Returns(jeopardyCategories);
+            _mockCache.Setup(c => c.DoubleJeopardyCategoryList).Returns(otherCategories);
+            _mockCache.Setup(c => c.FinalJeopardyCategoryList).Returns(otherCategories);
+
+            _mockLoader.Setup(l => l.LoadCategoryAsync(It.IsAny<ManifestCategory>()))
+                .ReturnsAsync(new Category { Title = "Loaded" });
+
+            var controller = CreateController();
+            await controller.GetRandomCategory(RoundDescriptor.Jeffpardy);
+
+            _mockLoader.Verify(l => l.LoadCategoryAsync(
+                It.Is<ManifestCategory>(mc => mc.Title == "J-0")), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetRandomCategory_UsesDoubleJeopardyCategoryList_ForSuperJeffpardy()
+        {
+            var otherCategories = CreateManifestCategories(1, "Other");
+            var doubleCategories = CreateManifestCategories(1, "DJ");
+
+            _mockCache.Setup(c => c.JeopardyCategoryList).Returns(otherCategories);
+            _mockCache.Setup(c => c.DoubleJeopardyCategoryList).Returns(doubleCategories);
+            _mockCache.Setup(c => c.FinalJeopardyCategoryList).Returns(otherCategories);
+
+            _mockLoader.Setup(l => l.LoadCategoryAsync(It.IsAny<ManifestCategory>()))
+                .ReturnsAsync(new Category { Title = "Loaded" });
+
+            var controller = CreateController();
+            await controller.GetRandomCategory(RoundDescriptor.SuperJeffpardy);
+
+            _mockLoader.Verify(l => l.LoadCategoryAsync(
+                It.Is<ManifestCategory>(mc => mc.Title == "DJ-0")), Times.Once);
+        }
+    }
+}

--- a/src/backend/Jeffpardy.Tests/CategoryMetadataControllerTests.cs
+++ b/src/backend/Jeffpardy.Tests/CategoryMetadataControllerTests.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using Moq;
+using Xunit;
+
+namespace Jeffpardy.Tests
+{
+    public class CategoryMetadataControllerTests
+    {
+        private readonly Mock<ISeasonManifestCache> _mockCache;
+
+        public CategoryMetadataControllerTests()
+        {
+            _mockCache = new Mock<ISeasonManifestCache>();
+        }
+
+        private CategoryMetadataController CreateController()
+        {
+            return new CategoryMetadataController(_mockCache.Object);
+        }
+
+        private List<ManifestCategory> CreateManifestCategories(params string[] titles)
+        {
+            var list = new List<ManifestCategory>();
+            for (int i = 0; i < titles.Length; i++)
+            {
+                list.Add(new ManifestCategory
+                {
+                    Title = titles[i],
+                    FileName = $"cat{i}.json",
+                    Index = i,
+                    Season = 1,
+                    AirDate = new DateTime(2023, 1, 1)
+                });
+            }
+            return list;
+        }
+
+        [Fact]
+        public void Search_ReturnsMatchingCategories()
+        {
+            var categories = CreateManifestCategories("History", "Science", "Historical Fiction");
+            _mockCache.Setup(c => c.JeopardyCategoryList).Returns(categories);
+
+            var controller = CreateController();
+            var result = controller.Search(RoundDescriptor.Jeffpardy, "Histor");
+
+            Assert.Equal(2, result.Length);
+        }
+
+        [Fact]
+        public void Search_IsCaseInsensitive()
+        {
+            var categories = CreateManifestCategories("Science", "SCIENCE Facts", "Other");
+            _mockCache.Setup(c => c.JeopardyCategoryList).Returns(categories);
+
+            var controller = CreateController();
+            var result = controller.Search(RoundDescriptor.Jeffpardy, "science");
+
+            Assert.Equal(2, result.Length);
+        }
+
+        [Fact]
+        public void Search_ReturnsCorrectMetadata()
+        {
+            var categories = CreateManifestCategories("Test Category");
+            _mockCache.Setup(c => c.JeopardyCategoryList).Returns(categories);
+
+            var controller = CreateController();
+            var result = controller.Search(RoundDescriptor.Jeffpardy, "Test");
+
+            Assert.Single(result);
+            Assert.Equal("Test Category", result[0].Title);
+            Assert.Equal(1, result[0].Season);
+            Assert.Equal("cat0.json", result[0].FileName);
+            Assert.Equal(0, result[0].Index);
+        }
+
+        [Fact]
+        public void Search_UsesDoubleJeopardyList_ForSuperJeffpardy()
+        {
+            var jeopardyCategories = CreateManifestCategories("J-Match");
+            var doubleJeopardyCategories = CreateManifestCategories("DJ-Match", "DJ-Other");
+
+            _mockCache.Setup(c => c.JeopardyCategoryList).Returns(jeopardyCategories);
+            _mockCache.Setup(c => c.DoubleJeopardyCategoryList).Returns(doubleJeopardyCategories);
+
+            var controller = CreateController();
+            var result = controller.Search(RoundDescriptor.SuperJeffpardy, "DJ");
+
+            Assert.Equal(2, result.Length);
+        }
+
+        [Fact]
+        public void Search_UsesFinalJeopardyList_ForFinalJeffpardy()
+        {
+            var finalCategories = CreateManifestCategories("Final-Match", "Final-Other");
+            _mockCache.Setup(c => c.FinalJeopardyCategoryList).Returns(finalCategories);
+
+            var controller = CreateController();
+            var result = controller.Search(RoundDescriptor.FinalJeffpardy, "Final");
+
+            Assert.Equal(2, result.Length);
+        }
+
+        [Fact]
+        public void Search_NoMatch_ReturnsEmptyArray()
+        {
+            var categories = CreateManifestCategories("History", "Science");
+            _mockCache.Setup(c => c.JeopardyCategoryList).Returns(categories);
+
+            var controller = CreateController();
+            var result = controller.Search(RoundDescriptor.Jeffpardy, "ZZZ");
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void Search_LimitsResultsTo100()
+        {
+            var titles = new string[150];
+            for (int i = 0; i < 150; i++)
+                titles[i] = $"Match-{i}";
+
+            var categories = CreateManifestCategories(titles);
+            _mockCache.Setup(c => c.JeopardyCategoryList).Returns(categories);
+
+            var controller = CreateController();
+            var result = controller.Search(RoundDescriptor.Jeffpardy, "Match");
+
+            Assert.Equal(100, result.Length);
+        }
+    }
+}

--- a/src/backend/Jeffpardy.Tests/DiagnosticsControllerTests.cs
+++ b/src/backend/Jeffpardy.Tests/DiagnosticsControllerTests.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using Moq;
+using Xunit;
+
+namespace Jeffpardy.Tests
+{
+    public class DiagnosticsControllerTests
+    {
+        private readonly Mock<ISeasonManifestCache> _mockCache;
+
+        public DiagnosticsControllerTests()
+        {
+            _mockCache = new Mock<ISeasonManifestCache>();
+        }
+
+        private DiagnosticsController CreateController()
+        {
+            return new DiagnosticsController(_mockCache.Object);
+        }
+
+        private void SetupCacheLists(int jeopardyCount, int doubleJeopardyCount, int finalJeopardyCount)
+        {
+            var jeopardyList = new List<ManifestCategory>();
+            for (int i = 0; i < jeopardyCount; i++)
+                jeopardyList.Add(new ManifestCategory
+                {
+                    Title = $"J-{i}",
+                    AirDate = new DateTime(2020, 1, 1).AddDays(i)
+                });
+
+            var doubleJeopardyList = new List<ManifestCategory>();
+            for (int i = 0; i < doubleJeopardyCount; i++)
+                doubleJeopardyList.Add(new ManifestCategory
+                {
+                    Title = $"DJ-{i}",
+                    AirDate = new DateTime(2021, 1, 1).AddDays(i)
+                });
+
+            var finalJeopardyList = new List<ManifestCategory>();
+            for (int i = 0; i < finalJeopardyCount; i++)
+                finalJeopardyList.Add(new ManifestCategory
+                {
+                    Title = $"FJ-{i}",
+                    AirDate = new DateTime(2022, 1, 1).AddDays(i)
+                });
+
+            _mockCache.Setup(c => c.JeopardyCategoryList).Returns(jeopardyList);
+            _mockCache.Setup(c => c.DoubleJeopardyCategoryList).Returns(doubleJeopardyList);
+            _mockCache.Setup(c => c.FinalJeopardyCategoryList).Returns(finalJeopardyList);
+        }
+
+        [Fact]
+        public void GetDiagnostics_ReturnsNonNull()
+        {
+            SetupCacheLists(1, 1, 1);
+
+            var controller = CreateController();
+            var result = controller.GetDiagnostics();
+
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public void GetDiagnostics_ReturnsCorrectJeopardyCategoryCount()
+        {
+            SetupCacheLists(10, 5, 3);
+
+            var controller = CreateController();
+            var result = controller.GetDiagnostics();
+
+            Assert.Equal(10, result.NumJeopardyCategories);
+        }
+
+        [Fact]
+        public void GetDiagnostics_ReturnsCorrectSuperJeffpardyCategoryCount()
+        {
+            SetupCacheLists(10, 5, 3);
+
+            var controller = CreateController();
+            var result = controller.GetDiagnostics();
+
+            Assert.Equal(5, result.NumSuperJeffpardyCategories);
+        }
+
+        [Fact]
+        public void GetDiagnostics_ReturnsCorrectFinalJeffpardyCategoryCount()
+        {
+            SetupCacheLists(10, 5, 3);
+
+            var controller = CreateController();
+            var result = controller.GetDiagnostics();
+
+            Assert.Equal(3, result.NumFinalJeffpardyCategories);
+        }
+
+        [Fact]
+        public void GetDiagnostics_ReturnsCorrectTotalCategoryCount()
+        {
+            SetupCacheLists(10, 5, 3);
+
+            var controller = CreateController();
+            var result = controller.GetDiagnostics();
+
+            Assert.Equal(18, result.NumCategories);
+        }
+
+        [Fact]
+        public void GetDiagnostics_ReturnsOldestCategory()
+        {
+            SetupCacheLists(2, 2, 2);
+
+            var controller = CreateController();
+            var result = controller.GetDiagnostics();
+
+            Assert.Equal(new DateTime(2020, 1, 1), result.OldestCategory);
+        }
+
+        [Fact]
+        public void GetDiagnostics_ReturnsNewestCategory()
+        {
+            SetupCacheLists(2, 2, 2);
+
+            var controller = CreateController();
+            var result = controller.GetDiagnostics();
+
+            // Newest is FinalJeopardy[1] = 2022-01-02
+            Assert.Equal(new DateTime(2022, 1, 2), result.NewestCategory);
+        }
+    }
+}

--- a/src/backend/Program.cs
+++ b/src/backend/Program.cs
@@ -24,6 +24,8 @@ if (builder.Environment.IsDevelopment())
 builder.Services.AddRazorPages();
 builder.Services.AddControllers();
 builder.Services.AddSignalR();
+builder.Services.AddSingleton<ISeasonManifestCache>(SeasonManifestCache.Instance);
+builder.Services.AddSingleton<ICategoryLoader>(AzureBlobCategoryLoader.Instance);
 builder.Services.AddSingleton<GameCache>();
 
 var app = builder.Build();

--- a/src/backend/api/CategoriesController.cs
+++ b/src/backend/api/CategoriesController.cs
@@ -10,7 +10,16 @@ namespace Jeffpardy
     [Route("api/Categories")]
     public class CategoriesController : Controller
     {
+        private readonly ISeasonManifestCache _cache;
+        private readonly ICategoryLoader _loader;
+
         Random rand = new Random();
+
+        public CategoriesController(ISeasonManifestCache cache, ICategoryLoader loader)
+        {
+            _cache = cache;
+            _loader = loader;
+        }
 
         [Route("GameData")]
         [HttpGet]
@@ -23,15 +32,15 @@ namespace Jeffpardy
                     new GameRound
                     {
                         Id = 0,
-                        Categories = await this.GetCategoriesAsync(SeasonManifestCache.Instance.JeopardyCategoryList)
+                        Categories = await this.GetCategoriesAsync(_cache.JeopardyCategoryList)
                     },
                     new GameRound
                     {
                         Id = 1,
-                        Categories = await this.GetCategoriesAsync(SeasonManifestCache.Instance.DoubleJeopardyCategoryList)
+                        Categories = await this.GetCategoriesAsync(_cache.DoubleJeopardyCategoryList)
                     }
                 },
-                FinalJeffpardyCategory = await this.FinalCategoryAndClueAsync(SeasonManifestCache.Instance.FinalJeopardyCategoryList)
+                FinalJeffpardyCategory = await this.FinalCategoryAndClueAsync(_cache.FinalJeopardyCategoryList)
 
             };
             return gd;
@@ -44,19 +53,19 @@ namespace Jeffpardy
             switch (roundDescriptor)
             {
                 case RoundDescriptor.Jeffpardy:
-                    categoryList = SeasonManifestCache.Instance.JeopardyCategoryList;
+                    categoryList = _cache.JeopardyCategoryList;
                     break;
                 case RoundDescriptor.SuperJeffpardy:
-                    categoryList = SeasonManifestCache.Instance.DoubleJeopardyCategoryList;
+                    categoryList = _cache.DoubleJeopardyCategoryList;
                     break;
                 case RoundDescriptor.FinalJeffpardy:
-                    categoryList = SeasonManifestCache.Instance.FinalJeopardyCategoryList;
+                    categoryList = _cache.FinalJeopardyCategoryList;
                     break;
             }
 
             int categoryIndex = rand.Next(0, categoryList.Count);
 
-            var category = await AzureBlobCategoryLoader.Instance.LoadCategoryAsync(categoryList[categoryIndex]);
+            var category = await _loader.LoadCategoryAsync(categoryList[categoryIndex]);
 
             return category;
         }
@@ -65,7 +74,7 @@ namespace Jeffpardy
         public async Task<Category> GetCategoryFromFilename(int season, string fileName)
         {
             int index = int.Parse(Request.Query["index"]);
-            var category = await AzureBlobCategoryLoader.Instance.LoadCategoryAsync(season, fileName, index);
+            var category = await _loader.LoadCategoryAsync(season, fileName, index);
 
             return category;
         }
@@ -90,7 +99,7 @@ namespace Jeffpardy
 
         private async Task<Category[]> LoadCategoriesAsync(List<ManifestCategory> manifestCategories)
         {
-            var categoryLoadTasks = manifestCategories.Select((mc) => AzureBlobCategoryLoader.Instance.LoadCategoryAsync(mc));
+            var categoryLoadTasks = manifestCategories.Select((mc) => _loader.LoadCategoryAsync(mc));
 
             await Task.WhenAll(categoryLoadTasks);
 
@@ -103,7 +112,7 @@ namespace Jeffpardy
 
             ManifestCategory finalManifestCategory = categoryList[categoryIndex];
 
-            var finalCategory = await AzureBlobCategoryLoader.Instance.LoadCategoryAsync(finalManifestCategory);
+            var finalCategory = await _loader.LoadCategoryAsync(finalManifestCategory);
 
             return finalCategory;
         }

--- a/src/backend/api/CategoryMetadataController.cs
+++ b/src/backend/api/CategoryMetadataController.cs
@@ -10,6 +10,12 @@ namespace Jeffpardy
     [Route("api/CategoryMetadata")]
     public class CategoryMetadataController : Controller
     {
+        private readonly ISeasonManifestCache _cache;
+
+        public CategoryMetadataController(ISeasonManifestCache cache)
+        {
+            _cache = cache;
+        }
 
         [Route("Search/{roundDescriptor}/{searchTerm}")]
         public CategoryMetadata[] Search(RoundDescriptor roundDescriptor, string searchTerm)
@@ -18,13 +24,13 @@ namespace Jeffpardy
             switch (roundDescriptor)
             {
                 case RoundDescriptor.Jeffpardy:
-                    categoryList = SeasonManifestCache.Instance.JeopardyCategoryList;
+                    categoryList = _cache.JeopardyCategoryList;
                     break;
                 case RoundDescriptor.SuperJeffpardy:
-                    categoryList = SeasonManifestCache.Instance.DoubleJeopardyCategoryList;
+                    categoryList = _cache.DoubleJeopardyCategoryList;
                     break;
                 case RoundDescriptor.FinalJeffpardy:
-                    categoryList = SeasonManifestCache.Instance.FinalJeopardyCategoryList;
+                    categoryList = _cache.FinalJeopardyCategoryList;
                     break;
             }
 

--- a/src/backend/api/DiagnosticsController.cs
+++ b/src/backend/api/DiagnosticsController.cs
@@ -12,21 +12,39 @@ namespace Jeffpardy
     [Route("api/Diagnostics")]
     public class DiagnosticsController : Controller
     {
+        private readonly ISeasonManifestCache _cache;
+
+        public DiagnosticsController(ISeasonManifestCache cache)
+        {
+            _cache = cache;
+        }
+
         [HttpGet]
         public JeffpardyDiagnostics GetDiagnostics()
         {
-            return new JeffpardyDiagnostics();
+            return new JeffpardyDiagnostics(_cache);
         }
 
     }
 
     public class JeffpardyDiagnostics
     {
+        private readonly ISeasonManifestCache _cache;
+
+        public JeffpardyDiagnostics()
+        {
+        }
+
+        public JeffpardyDiagnostics(ISeasonManifestCache cache)
+        {
+            _cache = cache;
+        }
+
         public int NumJeopardyCategories
         {
             get
             {
-                return SeasonManifestCache.Instance.JeopardyCategoryList.Count;
+                return _cache.JeopardyCategoryList.Count;
             }
         }
         
@@ -34,7 +52,7 @@ namespace Jeffpardy
         {
             get
             {
-                return SeasonManifestCache.Instance.DoubleJeopardyCategoryList.Count;
+                return _cache.DoubleJeopardyCategoryList.Count;
             }
         }
 
@@ -42,7 +60,7 @@ namespace Jeffpardy
         {
             get
             {
-                return SeasonManifestCache.Instance.FinalJeopardyCategoryList.Count;
+                return _cache.FinalJeopardyCategoryList.Count;
             }
         }
 
@@ -50,9 +68,9 @@ namespace Jeffpardy
         {
             get
             {
-                return SeasonManifestCache.Instance.JeopardyCategoryList.Count +
-                       SeasonManifestCache.Instance.DoubleJeopardyCategoryList.Count +
-                       SeasonManifestCache.Instance.FinalJeopardyCategoryList.Count;
+                return _cache.JeopardyCategoryList.Count +
+                       _cache.DoubleJeopardyCategoryList.Count +
+                       _cache.FinalJeopardyCategoryList.Count;
             }
         }
 
@@ -60,7 +78,7 @@ namespace Jeffpardy
         {
             get
             {
-                var allCategories = SeasonManifestCache.Instance.JeopardyCategoryList.Concat(SeasonManifestCache.Instance.DoubleJeopardyCategoryList).Concat(SeasonManifestCache.Instance.FinalJeopardyCategoryList);
+                var allCategories = _cache.JeopardyCategoryList.Concat(_cache.DoubleJeopardyCategoryList).Concat(_cache.FinalJeopardyCategoryList);
                 return allCategories.Min(c => c.AirDate);
             }
         }
@@ -69,7 +87,7 @@ namespace Jeffpardy
         {
             get
             {
-                var allCategories = SeasonManifestCache.Instance.JeopardyCategoryList.Concat(SeasonManifestCache.Instance.DoubleJeopardyCategoryList).Concat(SeasonManifestCache.Instance.FinalJeopardyCategoryList);
+                var allCategories = _cache.JeopardyCategoryList.Concat(_cache.DoubleJeopardyCategoryList).Concat(_cache.FinalJeopardyCategoryList);
                 return allCategories.Max(c => c.AirDate);
             }
         }


### PR DESCRIPTION
Closes #63. Replaces static singleton access with constructor injection, making all 3 API controllers unit-testable.