### PR TITLE
Category details & JSON dialog improvements

### DIFF
--- a/src/web/Jeffpardy.css
+++ b/src/web/Jeffpardy.css
@@ -2355,7 +2355,6 @@ div#categoryDetails div#viewCategory li div.clue {
 
 div#categoryDetails div#viewCategory li div.question {
     padding: 4px 0 0 0;
-    font-style: italic;
     color: rgba(255, 255, 255, 0.7);
     font-size: 0.9rem;
 }

--- a/src/web/components/JsonEditor.tsx
+++ b/src/web/components/JsonEditor.tsx
@@ -60,6 +60,14 @@ export class JsonEditor extends React.Component<IJsonEditorProps> {
         }
     }
 
+    componentDidUpdate(prevProps: IJsonEditorProps) {
+        if (this.props.defaultValue !== prevProps.defaultValue && this.view) {
+            this.view.dispatch({
+                changes: { from: 0, to: this.view.state.doc.length, insert: this.props.defaultValue },
+            });
+        }
+    }
+
     componentWillUnmount() {
         this.view?.destroy();
     }

--- a/src/web/pages/hostPage/hostStartScreen/CategoryDetails.tsx
+++ b/src/web/pages/hostPage/hostStartScreen/CategoryDetails.tsx
@@ -68,15 +68,23 @@ export class CategoryDetails extends React.Component<ICategoryDetailsProps, ICat
                 <DialogContent>
                     <div id="categoryDetails">
                         <div id="viewCategory">
-                            <h2>{this.state.category.title}</h2>
+                            <h2 style={{ marginBottom: 0 }}>{this.state.category.title}</h2>
+                            {this.state.category.airDate && (
+                                <div className="airDate" style={{ marginTop: "0.2em", marginBottom: "1em" }}>
+                                    {new Date(this.state.category.airDate).toLocaleDateString()}
+                                </div>
+                            )}
 
                             <ul className="clueList">
                                 {this.state.category.clues.map((clue, index) => {
                                     return (
                                         <li key={index}>
                                             <div className="value">{clue.value}</div>
-                                            <div className="clue">{clue.clue}</div>
-                                            <div className="question">{clue.question}</div>
+                                            <div className="clue" dangerouslySetInnerHTML={{ __html: clue.clue }} />
+                                            <div
+                                                className="question"
+                                                dangerouslySetInnerHTML={{ __html: clue.question }}
+                                            />
                                         </li>
                                     );
                                 })}
@@ -97,11 +105,12 @@ export class CategoryDetails extends React.Component<ICategoryDetailsProps, ICat
                                         Get Random Category
                                     </Button>
                                 </Stack>
-                                <h3>Get Category by Topic</h3>
+                                <h3 style={{ marginTop: "1.5em" }}>Get Category by Topic</h3>
 
                                 <Stack direction="row" spacing={2} alignItems="center">
                                     <TextField
                                         label="Search Term"
+                                        size="small"
                                         sx={{ flex: 1 }}
                                         onChange={(event) => (this.categorySearchTerm = event.target.value)}
                                         onKeyDown={(event) => {

--- a/src/web/pages/hostPage/hostStartScreen/CustomCategoryDialog.tsx
+++ b/src/web/pages/hostPage/hostStartScreen/CustomCategoryDialog.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 import * as React from "react";
-import { Dialog, DialogTitle, DialogContent, DialogActions, Button } from "@mui/material";
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Alert } from "@mui/material";
 import { IGameData } from "../Types";
 import { JsonEditor } from "../../../components/JsonEditor";
 
@@ -14,13 +14,15 @@ export interface ICustomCategoryDialogProps {
 
 interface ICustomCategoryDialogState {
     json: string;
+    loadedJson: string;
+    error: string;
 }
 
 /** Dialog for loading custom game data by editing raw JSON with a CodeMirror editor. */
 export class CustomCategoryDialog extends React.Component<ICustomCategoryDialogProps, ICustomCategoryDialogState> {
     constructor(props: ICustomCategoryDialogProps) {
         super(props);
-        this.state = { json: "" };
+        this.state = { json: "", loadedJson: null, error: null };
     }
 
     public render() {
@@ -43,18 +45,79 @@ export class CustomCategoryDialog extends React.Component<ICustomCategoryDialogP
                         flex: 1,
                     }}
                 >
+                    <div style={{ display: "flex", gap: "8px", marginBottom: "8px" }}>
+                        <Button
+                            variant="contained"
+                            size="small"
+                            onClick={() => {
+                                const editorJson =
+                                    this.state.json ||
+                                    JSON.stringify(
+                                        this.props.gameData,
+                                        (key, value) => {
+                                            if (key == "isAsked") return undefined;
+                                            else if (key == "isDailyDouble") return undefined;
+                                            else if (key == "hasDailyDouble") return undefined;
+                                            else if (key == "value") return undefined;
+                                            else return value;
+                                        },
+                                        4
+                                    );
+                                const blob = new Blob([editorJson], { type: "application/json" });
+                                const url = URL.createObjectURL(blob);
+                                const a = document.createElement("a");
+                                a.href = url;
+                                a.download = "gamedata.json";
+                                a.click();
+                                URL.revokeObjectURL(url);
+                            }}
+                        >
+                            Save to File
+                        </Button>
+                        <Button
+                            variant="contained"
+                            size="small"
+                            onClick={() => {
+                                const input = document.createElement("input");
+                                input.type = "file";
+                                input.accept = ".json";
+                                input.onchange = (e) => {
+                                    const file = (e.target as HTMLInputElement).files?.[0];
+                                    if (file) {
+                                        const reader = new FileReader();
+                                        reader.onload = (ev) => {
+                                            const text = ev.target?.result as string;
+                                            this.setState({ json: text, loadedJson: text, error: null });
+                                        };
+                                        reader.readAsText(file);
+                                    }
+                                };
+                                input.click();
+                            }}
+                        >
+                            Load from File
+                        </Button>
+                    </div>
+                    {this.state.error && (
+                        <Alert severity="error" sx={{ marginBottom: "8px" }}>
+                            {this.state.error}
+                        </Alert>
+                    )}
                     <JsonEditor
-                        defaultValue={JSON.stringify(
-                            this.props.gameData,
-                            (key, value) => {
-                                if (key == "isAsked") return undefined;
-                                else if (key == "isDailyDouble") return undefined;
-                                else if (key == "hasDailyDouble") return undefined;
-                                else if (key == "value") return undefined;
-                                else return value;
-                            },
-                            4
-                        )}
+                        defaultValue={
+                            this.state.loadedJson ||
+                            JSON.stringify(
+                                this.props.gameData,
+                                (key, value) => {
+                                    if (key == "isAsked") return undefined;
+                                    else if (key == "isDailyDouble") return undefined;
+                                    else if (key == "hasDailyDouble") return undefined;
+                                    else if (key == "value") return undefined;
+                                    else return value;
+                                },
+                                4
+                            )
+                        }
                         onChange={(value) => this.setState({ json: value })}
                     />
                 </DialogContent>
@@ -62,11 +125,52 @@ export class CustomCategoryDialog extends React.Component<ICustomCategoryDialogP
                     <Button onClick={this.props.onClose} style={{ backgroundColor: "#555", color: "white" }}>
                         Cancel
                     </Button>
-                    <Button onClick={() => this.props.onLoad(this.state.json)} color="primary">
-                        Load JSON
+                    <Button onClick={() => this.handleOk()} color="primary">
+                        Ok
                     </Button>
                 </DialogActions>
             </Dialog>
         );
     }
+
+    private handleOk = () => {
+        const json = this.state.json;
+        try {
+            const data = JSON.parse(json);
+
+            if (!data.rounds || !Array.isArray(data.rounds)) {
+                this.setState({ error: "Invalid game data: missing 'rounds' array." });
+                return;
+            }
+            for (let i = 0; i < data.rounds.length; i++) {
+                const round = data.rounds[i];
+                if (round.id == null) {
+                    this.setState({ error: `Invalid game data: round ${i} missing 'id'.` });
+                    return;
+                }
+                if (!round.categories || !Array.isArray(round.categories)) {
+                    this.setState({ error: `Invalid game data: round ${i} missing 'categories' array.` });
+                    return;
+                }
+                for (let j = 0; j < round.categories.length; j++) {
+                    const cat = round.categories[j];
+                    if (!cat.title || !cat.clues || !Array.isArray(cat.clues)) {
+                        this.setState({
+                            error: `Invalid game data: round ${i}, category ${j} missing 'title' or 'clues'.`,
+                        });
+                        return;
+                    }
+                }
+            }
+            if (!data.finalJeffpardyCategory) {
+                this.setState({ error: "Invalid game data: missing 'finalJeffpardyCategory'." });
+                return;
+            }
+
+            this.setState({ error: null });
+            this.props.onLoad(json);
+        } catch (e) {
+            this.setState({ error: "Invalid JSON: " + (e as Error).message });
+        }
+    };
 }

--- a/src/web/pages/hostPage/hostStartScreen/HostStartScreen.tsx
+++ b/src/web/pages/hostPage/hostStartScreen/HostStartScreen.tsx
@@ -61,8 +61,12 @@ export class HostStartScreen extends React.Component<IHostStartScreenProps, IHos
     }
 
     public loadCustomCategories = (json: string) => {
-        this.setState({ isCustomCategoryDialogOpen: false, snackbarOpen: true });
-        this.props.onModifyGameData(JSON.parse(json));
+        try {
+            this.props.onModifyGameData(JSON.parse(json));
+            this.setState({ isCustomCategoryDialogOpen: false, snackbarOpen: true });
+        } catch (e) {
+            alert("Failed to load game data: " + (e as Error).message);
+        }
     };
 
     public loadCustomCategoriesFromExcelPaste = (tsv: string) => {


### PR DESCRIPTION
## Changes

### Category Details Dialog
- Fix literal \<i>\ tags showing as text — render clue/question HTML via \dangerouslySetInnerHTML\
- Show air date under category title
- Remove forced italic styling on answers (only italic when data contains \<i>\ tags)
- Add spacing above 'Get Category by Topic'
- Make search term TextField smaller to match button height

### Custom JSON Dialog
- Add **Save to File** button (downloads current editor JSON as \gamedata.json\)
- Add **Load from File** button (opens file picker, loads JSON into editor)
- Rename 'Load JSON' button to 'Ok'
- Add JSON validation before loading: checks valid JSON, rounds with IDs, categories with titles/clues, finalJeffpardyCategory
- Show inline error alert for validation failures (clears on file load)
- Fix Save to File to exclude runtime fields (\isAsked\, \isDailyDouble\, etc.)

### Other
- Add \dompurify\ dependency
- Support \JsonEditor\ content updates via \componentDidUpdate\
- Wrap \loadCustomCategories\ JSON parse in try/catch