### PR TITLE
Fix mobile buzzer latency (~300ms tap delay)

### DIFF
--- a/src/web/Jeffpardy.css
+++ b/src/web/Jeffpardy.css
@@ -1946,6 +1946,7 @@ button#buzzer {
     border-radius: 50%;
     border: 3px solid rgba(255, 255, 255, 0.2);
     transition: background-color 0.15s ease, box-shadow 0.15s ease, transform 0.1s ease;
+    touch-action: manipulation;
 }
 
 button#buzzer div.reactionTime {

--- a/src/web/pages/playerPage/PlayerPage.tsx
+++ b/src/web/pages/playerPage/PlayerPage.tsx
@@ -358,7 +358,12 @@ export class PlayerPage extends React.Component<IPlayerPageProps, IPlayerPageSta
             .catch((err) => console.error(err));
     };
 
-    buzzIn = () => {
+    buzzIn = (e: React.MouseEvent | React.TouchEvent) => {
+        // Prevent touch events from also firing a redundant mousedown
+        if (e.type === "touchstart") {
+            e.preventDefault();
+        }
+
         if (this.state.buzzed) {
             Logger.debug("Buzzer clicked when already buzzed. Time:", new Date().getTime());
         } else if (this.state.buzzerLocked || this.state.buzzerEarlyClickLock) {
@@ -581,7 +586,12 @@ export class PlayerPage extends React.Component<IPlayerPageProps, IPlayerPageSta
                                         Click, touch or press SPACE to activate.
                                     </div>
 
-                                    <button id="buzzer" className={buzzerClassName} onMouseDown={this.buzzIn}>
+                                    <button
+                                        id="buzzer"
+                                        className={buzzerClassName}
+                                        onMouseDown={this.buzzIn}
+                                        onTouchStart={this.buzzIn}
+                                    >
                                         <div>{buzzerButtonText}</div>
                                         {showBuzzerReactionTime && (
                                             <div className="reactionTime">{this.state.reactionTime} ms</div>


### PR DESCRIPTION
## Summary

Mobile browser users experience ~300-550ms additional buzzer latency vs desktop, making it nearly impossible to win a buzz race against PC players.

## Changes

1. **Added `onTouchStart` handler** to the buzzer button — mobile browsers now fire the buzz immediately on touch instead of waiting ~300ms for the mousedown translation
2. **Added `touch-action: manipulation` CSS** — tells the browser to skip double-tap/pinch-zoom gesture detection on the buzzer
3. **Added `preventDefault()` on touchstart** — prevents the touch event from also firing a redundant mousedown

## Why this works

The ~300ms delay was caused by mobile browsers holding touch events to detect double-tap-to-zoom gestures before synthesizing a `mousedown`. By handling `touchstart` directly and setting `touch-action: manipulation`, we bypass this entirely.

Fixes #124