### PR TITLE
Add Getting Started (How to Play) guide

### DIFF
--- a/src/backend/Pages/HowToPlay.cshtml
+++ b/src/backend/Pages/HowToPlay.cshtml
@@ -1,0 +1,79 @@
+@page
+@model Jeffpardy.Pages.HowToPlayModel
+@{
+    Layout = "";
+}
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="~/js/dist/assets/style.css" />
+    <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
+    <title>How to Play &ndash; Jeffpardy!</title>
+</head>
+
+<body>
+    <div id="howToPlayPage">
+        <div class="howToPlayContent">
+            <div class="howToPlayHeader">
+                <img src="/images/JeffpardyTitle.png" class="howToPlayLogo" alt="Jeffpardy" />
+                <h1 class="jeffpardy-label">How to Play</h1>
+            </div>
+
+            <p class="howToPlayIntro">
+                Jeffpardy is a Jeopardy-style trivia game you play together in the same room (or over a
+                video call). One person <strong>hosts</strong> on a shared screen while everyone else
+                <strong>joins</strong> from their phones to buzz in.
+            </p>
+
+            <section class="howToPlaySection">
+                <h2 class="jeffpardy-label">Hosting a Game</h2>
+                <ol>
+                    <li>On the home screen, choose <strong>Host a Game</strong>.</li>
+                    <li>
+                        Pick your questions. You can use a built-in category pack, or supply your own
+                        <strong>custom categories</strong> &mdash; paste tab-separated clues, download the
+                        Excel template, or edit the raw JSON directly in the editor.
+                    </li>
+                    <li>
+                        Share the game with players: send them to the <strong>Join a Game</strong> page and
+                        give them the game code shown on your screen.
+                    </li>
+                    <li>
+                        Once teams have joined, start the game. Click a dollar value to reveal a clue, read it
+                        aloud, and call on the first team that buzzes in. Mark their answer
+                        <strong>correct</strong> or <strong>incorrect</strong> to update the score.
+                    </li>
+                    <li>
+                        Watch for <strong>Daily Doubles</strong> (the buzzed-in team wagers first) and finish
+                        each game with <strong>Final Jeffpardy</strong>, where every team submits a secret
+                        wager and written answer.
+                    </li>
+                </ol>
+                <p class="howToPlayTip">
+                    Tip: open the <strong>secondary display</strong> on a projector or TV so players see the
+                    board while you keep the controls on your own screen.
+                </p>
+            </section>
+
+            <section class="howToPlaySection">
+                <h2 class="jeffpardy-label">Joining as a Player</h2>
+                <ol>
+                    <li>On the home screen, choose <strong>Join a Game</strong>.</li>
+                    <li>Enter the <strong>game code</strong> from the host's screen and your team name.</li>
+                    <li>
+                        When a clue is up, tap the big <strong>buzzer</strong> as fast as you can. The first
+                        team in gets to answer &mdash; the host decides if you're right.
+                    </li>
+                </ol>
+            </section>
+
+            <div class="howToPlayActions">
+                <a href="/host" class="startPageButton jeffpardy-label"><span class="buttonLabel">Host a Game</span></a>
+                <a href="/player" class="startPageButton jeffpardy-label"><span class="buttonLabel">Join a Game</span></a>
+            </div>
+
+            <a href="/" class="howToPlayBackLink jeffpardy-label">&larr; Back to home</a>
+        </div>
+    </div>
+</body>

--- a/src/backend/Pages/HowToPlay.cshtml.cs
+++ b/src/backend/Pages/HowToPlay.cshtml.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Jeffpardy.Pages
+{
+    public class HowToPlayModel : PageModel
+    {
+        public void OnGet()
+        {
+
+        }
+    }
+}

--- a/src/web/Jeffpardy.css
+++ b/src/web/Jeffpardy.css
@@ -254,6 +254,148 @@ div#startPage .startPageButton:active {
     transform: translateY(0) scale(0.98);
 }
 
+div#startPage .startPageActions {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 28px;
+    position: relative;
+    z-index: 1;
+}
+
+div#startPage .howToPlayLink,
+#howToPlayPage .howToPlayBackLink {
+    color: white;
+    text-decoration: none;
+    font-size: 1.2rem;
+    opacity: 0.85;
+    border-bottom: 1px solid color-mix(in srgb, var(--color-gold) 40%, transparent);
+    padding-bottom: 2px;
+    transition: opacity 0.2s ease;
+}
+
+div#startPage .howToPlayLink:hover,
+#howToPlayPage .howToPlayBackLink:hover {
+    opacity: 1;
+}
+
+/* How to Play Guide */
+/* --------------------------------------------------*/
+#howToPlayPage {
+    position: relative;
+    min-height: 100%;
+    color: white;
+    background: radial-gradient(
+        ellipse at center,
+        color-mix(in srgb, var(--color-game-board), white 8%) 0%,
+        color-mix(in srgb, var(--color-game-board), black 30%) 100%
+    );
+    overflow-y: auto;
+    box-sizing: border-box;
+    padding: 40px 20px;
+    display: flex;
+    justify-content: center;
+}
+
+#howToPlayPage .howToPlayContent {
+    position: relative;
+    z-index: 1;
+    max-width: 760px;
+    width: 100%;
+}
+
+#howToPlayPage .howToPlayHeader {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 24px;
+}
+
+#howToPlayPage .howToPlayLogo {
+    max-height: 90px;
+    width: auto;
+    object-fit: contain;
+    filter: drop-shadow(0 10px 40px rgba(0, 0, 0, 0.6));
+}
+
+#howToPlayPage h1 {
+    font-size: 2.6rem;
+    margin: 0;
+}
+
+#howToPlayPage h2 {
+    font-size: 1.6rem;
+    margin: 0 0 12px 0;
+    color: var(--color-gold);
+}
+
+#howToPlayPage .howToPlayIntro {
+    font-size: 1.25rem;
+    line-height: 1.6;
+    text-align: center;
+    margin: 0 0 32px 0;
+}
+
+#howToPlayPage .howToPlaySection {
+    background: linear-gradient(135deg, #1a2a6c 0%, #0a1540 100%);
+    border: 1px solid color-mix(in srgb, var(--color-gold) 25%, transparent);
+    border-radius: 16px;
+    padding: 24px 28px;
+    margin-bottom: 24px;
+}
+
+#howToPlayPage .howToPlaySection ol {
+    font-size: 1.1rem;
+    line-height: 1.7;
+    margin: 0;
+    padding-left: 22px;
+}
+
+#howToPlayPage .howToPlaySection li {
+    margin-bottom: 10px;
+}
+
+#howToPlayPage .howToPlayTip {
+    margin: 16px 0 0 0;
+    font-size: 1rem;
+    font-style: italic;
+    opacity: 0.9;
+}
+
+#howToPlayPage .howToPlayActions {
+    display: flex;
+    gap: 24px;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin: 8px 0 28px 0;
+}
+
+#howToPlayPage .howToPlayActions .startPageButton {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 20px 40px;
+    border-radius: 16px;
+    text-decoration: none;
+    color: white;
+    font-size: 1.4rem;
+    min-width: 200px;
+    background: linear-gradient(135deg, #1a2a6c 0%, #0a1540 100%);
+    border: 1px solid color-mix(in srgb, var(--color-gold) 30%, transparent);
+    letter-spacing: 0.05em;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+#howToPlayPage .howToPlayActions .startPageButton:hover {
+    transform: translateY(-4px) scale(1.05);
+}
+
+#howToPlayPage .howToPlayBackLink {
+    display: block;
+    text-align: center;
+}
+
 div#startPage div.linkList {
     padding-top: 100px;
 }

--- a/src/web/pages/startPage/StartPage.test.tsx
+++ b/src/web/pages/startPage/StartPage.test.tsx
@@ -38,4 +38,10 @@ describe("StartPage", () => {
         const link = within(container).getByRole("link", { name: "Join a Game" });
         expect(link).toHaveAttribute("href", "/player");
     });
+
+    it('has a "How to Play" link pointing to /HowToPlay', () => {
+        const { container } = render(<StartPage />);
+        const link = within(container).getByRole("link", { name: /How to Play/i });
+        expect(link).toHaveAttribute("href", "/HowToPlay");
+    });
 });

--- a/src/web/pages/startPage/StartPage.tsx
+++ b/src/web/pages/startPage/StartPage.tsx
@@ -20,12 +20,17 @@ export class StartPage extends React.Component {
                     <div className="titleContainer">
                         <img src="/images/JeffpardyTitle.png" className="startPageLogo" alt="Jeffpardy" />
                     </div>
-                    <div className="startPageButtons">
-                        <a href="/host" className="startPageButton jeffpardy-label">
-                            <span className="buttonLabel">Host a Game</span>
-                        </a>
-                        <a href="/player" className="startPageButton jeffpardy-label">
-                            <span className="buttonLabel">Join a Game</span>
+                    <div className="startPageActions">
+                        <div className="startPageButtons">
+                            <a href="/host" className="startPageButton jeffpardy-label">
+                                <span className="buttonLabel">Host a Game</span>
+                            </a>
+                            <a href="/player" className="startPageButton jeffpardy-label">
+                                <span className="buttonLabel">Join a Game</span>
+                            </a>
+                        </div>
+                        <a href="/HowToPlay" className="howToPlayLink jeffpardy-label">
+                            New here? How to Play &rarr;
                         </a>
                     </div>
                 </div>


### PR DESCRIPTION
Closes #21

Adds a quick, player/host-facing **How to Play** guide and links it from the home page (the developer setup guide in the README is unchanged).

## Changes
- **`Pages/HowToPlay.cshtml`** (+ model): a themed static guide covering
  - **Hosting**: starting a game, custom categories (TSV / Excel template / JSON editor), sharing the game code, running the board, Daily Doubles, Final Jeffpardy, secondary display
  - **Joining**: entering the code, buzzing in
- **`StartPage.tsx`**: adds a "New here? How to Play →" link under the Host/Join buttons
- **`Jeffpardy.css`**: styles for the guide page + link, reusing existing theme variables
- **`StartPage.test.tsx`**: covers the new link

## Verification
- `npm run lint`, `prettier --check`, `npm run build` ✅
- `npm test` → 171 passed ✅
- `dotnet build` ✅; ran the app and confirmed `GET /HowToPlay` returns 200 with all sections