### PR TITLE
Fix How to Play page not scrolling

### DIFF
--- a/src/web/Jeffpardy.css
+++ b/src/web/Jeffpardy.css
@@ -283,7 +283,7 @@ div#startPage .howToPlayLink:hover,
 /* --------------------------------------------------*/
 #howToPlayPage {
     position: relative;
-    min-height: 100%;
+    height: 100%;
     color: white;
     background: radial-gradient(
         ellipse at center,


### PR DESCRIPTION
The `/HowToPlay` page is a direct child of `<body>`, which is `height: 100%; overflow: hidden`. `#howToPlayPage` used `min-height: 100%`, so on smaller viewports it grew taller than the screen and the overflow was clipped by the body with no scrollbar.

Fix: use a definite `height: 100%` so `#howToPlayPage`'s own `overflow-y: auto` produces an internal scrollbar.