### PR TITLE
Fix late buzz-in accepted after host moves on (#135)

### DIFF
--- a/src/backend/Game.cs
+++ b/src/backend/Game.cs
@@ -93,6 +93,14 @@ namespace Jeffpardy
         Player winningBuzzerUser;
 
         /// <summary>
+        /// Whether the buzzer is currently open for buzz-ins. Buzzes are only
+        /// accepted while this is true. It is closed once a winner is assigned
+        /// or the host moves on (resets the buzzer), so a late buzz arriving
+        /// after the host has shown the answer is ignored.
+        /// </summary>
+        bool isBuzzerActive = false;
+
+        /// <summary>
         /// All buzz attempts for the current buzzer window, sorted by time when sent.
         /// </summary>
         readonly List<(Player Player, int TimeInMilliseconds)> buzzerAttempts = new List<(Player, int)>();
@@ -200,6 +208,7 @@ namespace Jeffpardy
                 this.winningBuzzerTimeInMilliseconds = int.MaxValue;
                 this.buzzerAttempts.Clear();
                 this.buzzerWindowTimer.Stop();
+                this.isBuzzerActive = false;
             }
             await gameHubContext.Clients.Group(this.GameCode).SendAsync("resetBuzzer");
         }
@@ -212,6 +221,7 @@ namespace Jeffpardy
                 this.winningBuzzerTimeInMilliseconds = int.MaxValue;
                 this.buzzerAttempts.Clear();
                 this.buzzerWindowTimer.Stop();
+                this.isBuzzerActive = true;
             }
             await gameHubContext.Clients.Group(this.GameCode).SendAsync("activateBuzzer");
         }
@@ -229,6 +239,10 @@ namespace Jeffpardy
                 {
                     return;
                 }
+
+                // Close the buzzer once a winner is assigned so late buzzes
+                // (or buzzes after the host moves on) are not accepted.
+                this.isBuzzerActive = false;
 
                 this.buzzerWinnerTeams.Add(this.winningBuzzerUser.Team);
                 winner = this.winningBuzzerUser;
@@ -249,6 +263,15 @@ namespace Jeffpardy
             lock (_lock)
             {
                 if (!players.TryGetValue(connectionId, out Player buzzerUser))
+                {
+                    return;
+                }
+
+                // Ignore buzzes once the buzzer has closed (winner assigned or the
+                // host moved on and reset the buzzer). Without this, a late buzz
+                // would restart the buzzer window and broadcast a stale winner that
+                // leaves players stuck showing "buzzed in".
+                if (!this.isBuzzerActive)
                 {
                     return;
                 }

--- a/src/backend/Jeffpardy.Tests/GameTests.cs
+++ b/src/backend/Jeffpardy.Tests/GameTests.cs
@@ -149,6 +149,7 @@ namespace Jeffpardy.Tests
             var game = CreateGame();
             await game.ConnectPlayerAsync("conn1", "TeamA", "Alice");
 
+            await game.ActivateBuzzerAsync();
             game.BuzzIn("conn1", 100, 0);
 
             // No exception means timer started successfully
@@ -161,6 +162,7 @@ namespace Jeffpardy.Tests
             await game.ConnectPlayerAsync("conn1", "TeamA", "Alice");
             await game.ConnectPlayerAsync("conn2", "TeamB", "Bob");
 
+            await game.ActivateBuzzerAsync();
             game.BuzzIn("conn1", 200, 0);
             game.BuzzIn("conn2", 100, 0);
 
@@ -182,6 +184,7 @@ namespace Jeffpardy.Tests
             await game.ConnectPlayerAsync("conn2", "TeamB", "Bob");
 
             // First round: TeamA wins
+            await game.ActivateBuzzerAsync();
             game.BuzzIn("conn1", 100, 0);
             await game.AssignWinnerAsync();
 
@@ -209,6 +212,7 @@ namespace Jeffpardy.Tests
             await game.ConnectPlayerAsync("conn2", "TeamB", "Bob");
 
             // Alice buzzes at 200ms with -100 handicap (should be ignored, time stays 200)
+            await game.ActivateBuzzerAsync();
             game.BuzzIn("conn1", 200, -100);
             // Bob buzzes at 150ms with 0 handicap
             game.BuzzIn("conn2", 150, 0);
@@ -232,6 +236,7 @@ namespace Jeffpardy.Tests
             await game.ConnectPlayerAsync("conn1", "TeamA", "Alice");
             await game.ConnectPlayerAsync("conn2", "TeamB", "Bob");
 
+            await game.ActivateBuzzerAsync();
             game.BuzzIn("conn1", baseTime, handicap);
             game.BuzzIn("conn2", expectedEffectiveTime + 1, 0);
 
@@ -270,6 +275,7 @@ namespace Jeffpardy.Tests
             await game.ConnectPlayerAsync("conn2", "TeamB", "Bob");
 
             // TeamA wins
+            await game.ActivateBuzzerAsync();
             game.BuzzIn("conn1", 100, 0);
             await game.AssignWinnerAsync();
 
@@ -282,6 +288,7 @@ namespace Jeffpardy.Tests
                 It.IsAny<CancellationToken>()), Times.Once);
 
             // After reset, TeamA should be able to buzz in again (not skipped)
+            await game.ActivateBuzzerAsync();
             game.BuzzIn("conn1", 100, 0);
             await game.AssignWinnerAsync();
 
@@ -292,6 +299,27 @@ namespace Jeffpardy.Tests
                     args.Length >= 2 &&
                     ((Player)args[0]!).Name == "Alice"),
                 It.IsAny<CancellationToken>()), Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task BuzzIn_AfterBuzzerClosed_DoesNotAssignWinner()
+        {
+            var game = CreateGame();
+            await game.ConnectPlayerAsync("conn1", "TeamA", "Alice");
+
+            // Host has moved on / shown the answer: buzzer was reset (closed).
+            await game.ActivateBuzzerAsync();
+            await game.ResetBuzzerAsync();
+
+            // A late buzz arrives after the host moved on.
+            game.BuzzIn("conn1", 100, 0);
+            await game.AssignWinnerAsync();
+
+            // No winner should be broadcast for the late buzz.
+            _mockGroupProxy.Verify(c => c.SendCoreAsync(
+                "assignWinner",
+                It.IsAny<object?[]>(),
+                It.IsAny<CancellationToken>()), Times.Never);
         }
 
         [Fact]


### PR DESCRIPTION
Adds a server-side `isBuzzerActive` gate in `Game.cs`. The buzzer opens on `ActivateBuzzerAsync` and closes on `ResetBuzzerAsync` and once a winner is assigned. `BuzzIn` ignores buzzes while the buzzer is closed.

**Root cause:** a buzz arriving after the host showed the answer restarted the 500ms buzzer window and broadcast a stale `assignWinner`, leaving players stuck showing "buzzed in" while the game moved on.

Added regression test `BuzzIn_AfterBuzzerClosed_DoesNotAssignWinner`. Existing buzz tests updated to activate the buzzer first.

Closes #135