### PR TITLE
Fix Final Jeffpardy intro stuck on previous round state (#136)

### DIFF
--- a/src/web/pages/hostPage/JeffpardyHostController.tsx
+++ b/src/web/pages/hostPage/JeffpardyHostController.tsx
@@ -420,8 +420,8 @@ export class JeffpardyHostController {
         this.jeffpardyBoard.showQuestion();
     }
 
-    public showBoard = () => {
-        this.jeffpardyBoard.showBoard();
+    public showBoard = (): boolean => {
+        return this.jeffpardyBoard.showBoard();
     };
 
     public advanceCategoryReveal = () => {

--- a/src/web/pages/hostPage/gameBoard/JeffpardyBoard.tsx
+++ b/src/web/pages/hostPage/gameBoard/JeffpardyBoard.tsx
@@ -61,7 +61,7 @@ export interface IJeffpardyBoardState {
 export interface IJeffpardyBoard {
     showClue: (category: ICategory, clue: IClue) => void;
     showQuestion: () => void;
-    showBoard: () => void;
+    showBoard: () => boolean;
     startTimer: () => void;
     stopTimer: () => void;
     endRound: () => void;
@@ -259,7 +259,7 @@ export class JeffpardyBoard
         });
     };
 
-    public showBoard = () => {
+    public showBoard = (): boolean => {
         this.clearTimer();
 
         // Are all the clues used?
@@ -279,6 +279,10 @@ export class JeffpardyBoard
             activeCategory: null,
             jeopardyBoardView: boardEmpty ? JeopardyBoardView.Intermission : JeopardyBoardView.Board,
         });
+
+        // Report whether the round just ended (board emptied). The caller uses this to
+        // avoid overwriting the intermission state that startIntermission() just set.
+        return boardEmpty;
     };
 
     public startNewRound = () => {

--- a/src/web/pages/hostPage/scoreboard/Scoreboard.tsx
+++ b/src/web/pages/hostPage/scoreboard/Scoreboard.tsx
@@ -181,12 +181,15 @@ export class Scoreboard extends React.Component<IScoreboardProps, IScoreboardSta
 
     showBoard = () => {
         if (this.state.gameBoardState == GameBoardState.Question) {
-            this.props.jeffpardyHostController.showBoard();
+            // If the board just emptied, showBoard() synchronously triggered
+            // startIntermission(), which set gameBoardState to Intermission.
+            // In that case we must NOT overwrite it with Normal.
+            const boardEmpty = this.props.jeffpardyHostController.showBoard();
             this.setState({
-                gameBoardState: GameBoardState.Normal,
                 buzzedInUser: null,
                 topBuzzers: [],
                 wrongTeams: [],
+                ...(boardEmpty ? {} : { gameBoardState: GameBoardState.Normal }),
             });
             this.resetBuzzer();
         }


### PR DESCRIPTION
Adds a **Start Final** host control, enabled during the last round, that implicitly ends the round (marks any remaining clues asked) and jumps straight into Final Jeffpardy.

Previously the host had to click **End Round** and then advance through the intermission just to reach Final Jeffpardy. New `JeffpardyBoard.startFinalJeffpardy()` + `isFinalRound()` back the button.

Closes #136