### PR TITLE
Highlight the winning team at end of game (#137)

### DIFF
--- a/src/backend/Game.cs
+++ b/src/backend/Game.cs
@@ -310,6 +310,11 @@ namespace Jeffpardy
             await gameHubContext.Clients.Group(this.GameCode).SendAsync("broadcastScores", scores);
         }
 
+        public async Task EndGameAsync(Dictionary<string, int> scores)
+        {
+            await gameHubContext.Clients.Group(this.GameCode).SendAsync("endGame", scores);
+        }
+
         public async Task StartFinalJeffpardyAsync(Dictionary<string, int> scores)
         {
             await gameHubContext.Clients.Group(this.GameCode).SendAsync("startFinalJeffpardy", scores);

--- a/src/backend/GameCache.cs
+++ b/src/backend/GameCache.cs
@@ -115,6 +115,13 @@ namespace Jeffpardy
             await game.BroadcastScoresAsync(scores);
         }
 
+        public async Task EndGameAsync(string gameCode, Dictionary<string, int> scores)
+        {
+            Game game = this.GetGame(gameCode);
+            if (game == null) return;
+            await game.EndGameAsync(scores);
+        }
+
         public async Task StartFinalJeffpardyAsync(string gameCode, Dictionary<string, int> scores)
         {
             Game game = this.GetGame(gameCode);

--- a/src/backend/Hubs/GameHub.cs
+++ b/src/backend/Hubs/GameHub.cs
@@ -141,6 +141,19 @@ namespace Jeffpardy.Hubs
             }
         }
 
+        public async Task EndGame(string gameCode, Dictionary<string, int> scores)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(gameCode)) { throw new ArgumentNullException("gameCode"); }
+                await gameCache.EndGameAsync(gameCode, scores);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error in EndGame for game {GameCode}", gameCode);
+            }
+        }
+
         public async Task StartFinalJeffpardy(string gameCode, Dictionary<string, int> scores)
         {
             try {

--- a/src/web/Jeffpardy.css
+++ b/src/web/Jeffpardy.css
@@ -2559,6 +2559,20 @@ div.buzzerUserListView .playerScoreTable .scoreCol.negative {
     color: #f44336;
 }
 
+div.buzzerUserListView .playerScoreTable tbody tr.winningTeam {
+    background-color: rgba(76, 175, 80, 0.18);
+    box-shadow: inset 0 0 0 2px #4caf50;
+}
+
+div.buzzerUserListView .playerScoreTable tbody tr.winningTeam .teamNameCol,
+div.buzzerUserListView .playerScoreTable tbody tr.winningTeam .scoreCol {
+    color: #7be07f;
+}
+
+div.buzzerUserListView .playerScoreTable .winnerCrown {
+    margin-right: 6px;
+}
+
 /* Phone responsive layout for player/buzzer page */
 @media (max-width: 600px) {
     div#playerPageMain {

--- a/src/web/components/playerList/PlayerList.test.tsx
+++ b/src/web/components/playerList/PlayerList.test.tsx
@@ -90,6 +90,29 @@ describe("PlayerList", () => {
             expect(teamNames).toEqual(["Beta", "Alpha"]);
         });
 
+        it("does not highlight any winner when hilightWinner is not set", () => {
+            const teams = makeTeams();
+            const scores = { Alpha: 100, Beta: 500 };
+            const { container } = render(<PlayerList teams={teams} scores={scores} />);
+            expect(container.querySelectorAll(".playerScoreTable tbody tr.winningTeam").length).toBe(0);
+        });
+
+        it("highlights the top-scoring team when hilightWinner is set", () => {
+            const teams = makeTeams();
+            const scores = { Alpha: 100, Beta: 500 };
+            const { container } = render(<PlayerList teams={teams} scores={scores} hilightWinner={true} />);
+            const winners = container.querySelectorAll(".playerScoreTable tbody tr.winningTeam");
+            expect(winners.length).toBe(1);
+            expect(winners[0].querySelector(".teamNameCol")!.textContent).toContain("Beta");
+        });
+
+        it("highlights all tied top-scoring teams when hilightWinner is set", () => {
+            const teams = makeTeams();
+            const scores = { Alpha: 500, Beta: 500 };
+            const { container } = render(<PlayerList teams={teams} scores={scores} hilightWinner={true} />);
+            expect(container.querySelectorAll(".playerScoreTable tbody tr.winningTeam").length).toBe(2);
+        });
+
         it("renders scores as plain numbers without commas or $", () => {
             const teams = makeTeams();
             const scores = { Alpha: 1234567, Beta: 500 };

--- a/src/web/components/playerList/PlayerList.tsx
+++ b/src/web/components/playerList/PlayerList.tsx
@@ -9,6 +9,7 @@ export interface IPlayerListProps {
     teams: TeamDictionary;
     scores?: { [key: string]: number };
     lockedInPlayerIds?: string[];
+    hilightWinner?: boolean;
 }
 
 /** Displays a list of teams and their players, optionally showing scores and locked-in indicators.
@@ -60,6 +61,16 @@ export class PlayerList extends React.Component<IPlayerListProps> {
     private renderScoreTable() {
         const teamNames = this.getSortedTeamNames();
 
+        // When highlighting the winner (end of game), find the top score so we can
+        // mark every team that achieved it (handles ties).
+        let topScore = Number.NEGATIVE_INFINITY;
+        if (this.props.hilightWinner) {
+            teamNames.forEach((teamName) => {
+                const score = this.props.scores[teamName] ?? 0;
+                if (score > topScore) topScore = score;
+            });
+        }
+
         return (
             <table className="playerScoreTable">
                 <thead>
@@ -71,14 +82,19 @@ export class PlayerList extends React.Component<IPlayerListProps> {
                 <tbody>
                     {teamNames.map((teamName) => {
                         const score = this.props.scores[teamName] ?? 0;
+                        const isWinner = this.props.hilightWinner && score == topScore;
                         return (
                             <tr
                                 key={teamName}
+                                className={isWinner ? "winningTeam" : ""}
                                 ref={(el) => {
                                     if (el) this.rowRefs.set(teamName, el);
                                 }}
                             >
-                                <td className="teamNameCol">{teamName}</td>
+                                <td className="teamNameCol">
+                                    {isWinner && <span className="winnerCrown">👑</span>}
+                                    {teamName}
+                                </td>
                                 <td className={"scoreCol" + (score < 0 ? " negative" : "")}>{score}</td>
                             </tr>
                         );

--- a/src/web/pages/hostPage/HostSignalRClient.tsx
+++ b/src/web/pages/hostPage/HostSignalRClient.tsx
@@ -13,6 +13,7 @@ export interface IHostSignalRClient {
     showClue: (clue: IClue) => void;
     startRound: (round: IGameRound) => void;
     broadcastScores: (scores: { [key: string]: number }) => void;
+    endGame: (scores: { [key: string]: number }) => void;
     startFinalJeffpardy: (scores: { [key: string]: number }) => void;
     showFinalJeffpardyClue: () => void;
     endFinalJeffpardy: () => void;
@@ -95,6 +96,12 @@ export class HostSignalRClient implements IHostSignalRClient {
         Logger.debug("HostSignalRClient:broadcastScores", scores);
 
         this.hubConnection.invoke("broadcastScores", this.gameCode, scores).catch((err) => console.error(err));
+    };
+
+    public endGame = (scores: { [key: string]: number }) => {
+        Logger.debug("HostSignalRClient:endGame", scores);
+
+        this.hubConnection.invoke("endGame", this.gameCode, scores).catch((err) => console.error(err));
     };
 
     public startFinalJeffpardy = (scores: { [key: string]: number }) => {

--- a/src/web/pages/hostPage/JeffpardyHostController.tsx
+++ b/src/web/pages/hostPage/JeffpardyHostController.tsx
@@ -346,6 +346,14 @@ export class JeffpardyHostController {
         this.hostSignalRClient.broadcastScores(scores);
     };
 
+    public endGame = () => {
+        const scores: { [key: string]: number } = {};
+        Object.keys(this.teams).forEach((teamName) => {
+            scores[teamName] = this.teams[teamName].score;
+        });
+        this.hostSignalRClient.endGame(scores);
+    };
+
     public submitWager(user: IPlayer, wager: number) {
         // TODO:  Something to stop a wager from being entered twice, or after the clue is shown
         // Or, take this all out of the controller

--- a/src/web/pages/hostPage/gameBoard/JeffpardyBoard.tsx
+++ b/src/web/pages/hostPage/gameBoard/JeffpardyBoard.tsx
@@ -411,6 +411,7 @@ export class JeffpardyBoard
     onTallyCompleted = () => {
         Logger.debug("JeffpardyBoard:onTallyCompleted");
         this.props.jeffpardyHostController.setViewMode(HostPageViewMode.End);
+        this.props.jeffpardyHostController.endGame();
         this.setState({
             jeopardyBoardView: JeopardyBoardView.EndGame,
         });

--- a/src/web/pages/hostPage/scoreboard/ScoreboardEntry.test.tsx
+++ b/src/web/pages/hostPage/scoreboard/ScoreboardEntry.test.tsx
@@ -117,7 +117,7 @@ describe("ScoreboardEntry", () => {
         expect(entry.className).toContain("winningTeam");
     });
 
-    it("does not add extra classes when buzzerState is not Off even if isControllingTeam and isWinningTeam", () => {
+    it("does not add controllingTeam class when buzzerState is not Off, but still marks the winner", () => {
         const { container } = render(
             <ScoreboardEntry
                 teamName="Alpha"
@@ -130,6 +130,7 @@ describe("ScoreboardEntry", () => {
         );
         const entry = container.querySelector(".scoreboardEntry") as HTMLElement;
         expect(entry.className).not.toContain("controllingTeam");
-        expect(entry.className).not.toContain("winningTeam");
+        // The winner highlight is shown at end of game regardless of buzzer state.
+        expect(entry.className).toContain("winningTeam");
     });
 });

--- a/src/web/pages/hostPage/scoreboard/ScoreboardEntry.tsx
+++ b/src/web/pages/hostPage/scoreboard/ScoreboardEntry.tsx
@@ -44,7 +44,7 @@ export class ScoreboardEntry extends React.Component<IScoreboardEntryProps> {
             scoreboardEntryClass += " controllingTeam";
         }
 
-        if (this.props.buzzerState == ScoreboardEntryBuzzerState.Off && this.props.isWinningTeam) {
+        if (this.props.isWinningTeam) {
             scoreboardEntryClass += " winningTeam";
         }
 

--- a/src/web/pages/playerPage/PlayerPage.tsx
+++ b/src/web/pages/playerPage/PlayerPage.tsx
@@ -51,6 +51,7 @@ export interface IPlayerPageState {
     finalJeffpardyAnswerEnabled: boolean;
     finalJeffpardyScores: { [key: string]: number };
     scores: { [key: string]: number };
+    gameOver: boolean;
     lockedInPlayerIds: string[];
     gameCodeInputLength: number;
     toastMessage: string; // Transient notification text; auto-clears after 3s via showToast
@@ -109,6 +110,7 @@ export class PlayerPage extends React.Component<IPlayerPageProps, IPlayerPageSta
             finalJeffpardyAnswerEnabled: true,
             finalJeffpardyScores: null,
             scores: null,
+            gameOver: false,
             lockedInPlayerIds: [],
             gameCodeInputLength: 0,
             toastMessage: null,
@@ -171,6 +173,11 @@ export class PlayerPage extends React.Component<IPlayerPageProps, IPlayerPageSta
         hubConnection.on("broadcastScores", (scores: { [key: string]: number }) => {
             Logger.debug("Broadcast Scores: " + JSON.stringify(scores));
             this.setState({ scores: scores });
+        });
+
+        hubConnection.on("endGame", (scores: { [key: string]: number }) => {
+            Logger.debug("Game Over: " + JSON.stringify(scores));
+            this.setState({ scores: scores, gameOver: true });
         });
 
         hubConnection.on("assignWinner", (user: IPlayer, reactionTime: number) => {
@@ -700,12 +707,19 @@ export class PlayerPage extends React.Component<IPlayerPageProps, IPlayerPageSta
                         </div>
 
                         <div className="buzzerUserListView">
-                            <h1>{this.state.scores ? "Scores" : "Current Players"}</h1>
+                            <h1>
+                                {this.state.gameOver
+                                    ? "Final Scores"
+                                    : this.state.scores
+                                    ? "Scores"
+                                    : "Current Players"}
+                            </h1>
                             <div>
                                 <PlayerList
                                     teams={this.state.teams}
                                     scores={this.state.scores}
                                     lockedInPlayerIds={this.state.lockedInPlayerIds}
+                                    hilightWinner={this.state.gameOver}
                                 />
                             </div>
                         </div>


### PR DESCRIPTION
Broadcasts a new `endGame` event carrying final scores to all players when the Final Jeffpardy tally completes.

- Players now render a **Final Scores** table with the top-scoring team (or tied teams) highlighted with a green outline + 👑.
- The host scoreboard winner highlight no longer depends on buzzer state, so it shows reliably at game end.
- Adds `Game.EndGameAsync` / `GameCache.EndGameAsync` / `GameHub.EndGame` and the host client/controller plumbing.

Closes #137