### PR TITLE
Highlight locked-in wagers with a green outline in Final Jeffpardy (#138)

### DIFF
--- a/src/web/Jeffpardy.css
+++ b/src/web/Jeffpardy.css
@@ -1485,7 +1485,10 @@ ul.finalJeffpardySubmissionList .fjPlayer {
     display: flex;
     justify-content: space-between;
     font-size: 0.85rem;
-    padding: 2px 0;
+    padding: 2px 6px;
+    border: 2px solid transparent;
+    border-radius: 4px;
+    transition: border-color 0.3s ease, background-color 0.3s ease;
 }
 
 ul.finalJeffpardySubmissionList .fjPlayerStatus {
@@ -1495,8 +1498,13 @@ ul.finalJeffpardySubmissionList .fjPlayerStatus {
     letter-spacing: 0.05em;
 }
 
+ul.finalJeffpardySubmissionList .fjPlayer.received {
+    border-color: #4caf50;
+    background-color: rgba(76, 175, 80, 0.12);
+}
+
 ul.finalJeffpardySubmissionList .fjPlayer.received .fjPlayerStatus {
-    color: var(--color-gold);
+    color: #7be07f;
     opacity: 1;
 }
 


### PR DESCRIPTION
Each player's box in the Final Jeffpardy wager submission list now gets a clear **green outline** and tint once their wager is locked in, so it's easy to see at a glance who has submitted.

The host already receives per-wager `submitWager` updates live and re-renders the list, so this is a styling-only change to `.fjPlayer.received`.

Closes #138