### PR TITLE
Keep screen awake on host, secondary, and buzzer pages

### DIFF
--- a/src/web/pages/hostPage/HostPage.tsx
+++ b/src/web/pages/hostPage/HostPage.tsx
@@ -15,6 +15,7 @@ import * as QRCode from "qrcode.react";
 import { IGameData, FinalJeffpardyAnswerDictionary, FinalJeffpardyWagerDictionary } from "./Types";
 import { ICategory, ITeam, TeamDictionary } from "../../Types";
 import { ScreenSizeWarning } from "../../components/screenSizeWarning/ScreenSizeWarning";
+import { WakeLock } from "../../utilities/WakeLock";
 
 export enum HostPageViewMode {
     Start,
@@ -56,6 +57,7 @@ export class HostPage extends React.Component<IHostPageProps, IHostPageState> {
     jeffpardyHostController: JeffpardyHostController;
     gameCode: string;
     hostCode: string;
+    wakeLock: WakeLock = new WakeLock();
     constructor(props: IHostPageProps) {
         super(props);
 
@@ -139,6 +141,9 @@ export class HostPage extends React.Component<IHostPageProps, IHostPageState> {
     }
 
     public componentDidMount() {
+        // Keep the host display awake for the duration of the game.
+        void this.wakeLock.enable();
+
         if (this.jeffpardyHostController.hasStoredAccessCode()) {
             this.jeffpardyHostController.validateAccessCode(
                 this.jeffpardyHostController.accessCode,
@@ -151,6 +156,10 @@ export class HostPage extends React.Component<IHostPageProps, IHostPageState> {
                 }
             );
         }
+    }
+
+    public componentWillUnmount() {
+        void this.wakeLock.disable();
     }
 
     public startIntro = () => {

--- a/src/web/pages/hostSecondaryPage/HostSecondaryPage.tsx
+++ b/src/web/pages/hostSecondaryPage/HostSecondaryPage.tsx
@@ -9,6 +9,7 @@ import { Logger } from "../../utilities/Logger";
 import { IClue, IPlayer, IBuzzerAttempt } from "../../Types";
 import { sanitizeHtml } from "../../utilities/sanitize";
 import { Debug } from "../../utilities/Debug";
+import { WakeLock } from "../../utilities/WakeLock";
 
 import { IGameRound } from "../hostPage/Types";
 
@@ -34,6 +35,7 @@ export interface IHostSecondaryPageState {
  * Secondary Host Page
  */
 export class HostSecondaryPage extends React.Component<IHostSecondaryPageProps, IHostSecondaryPageState> {
+    wakeLock: WakeLock = new WakeLock();
     constructor(props: IHostSecondaryPageProps) {
         super(props);
 
@@ -53,6 +55,9 @@ export class HostSecondaryPage extends React.Component<IHostSecondaryPageProps, 
     }
 
     componentDidMount = () => {
+        // Keep the secondary/TV display awake for the duration of the game.
+        void this.wakeLock.enable();
+
         const hubConnection: signalR.HubConnection = new signalR.HubConnectionBuilder()
             .withUrl("/hub/game")
             .withAutomaticReconnect()
@@ -120,6 +125,7 @@ export class HostSecondaryPage extends React.Component<IHostSecondaryPageProps, 
     };
 
     componentWillUnmount() {
+        void this.wakeLock.disable();
         this.state.hubConnection.stop();
     }
 

--- a/src/web/pages/playerPage/PlayerPage.tsx
+++ b/src/web/pages/playerPage/PlayerPage.tsx
@@ -11,6 +11,7 @@ import { PlayerList } from "../../components/playerList/PlayerList";
 import { ITeam } from "../../Types";
 import { Debug } from "../../utilities/Debug";
 import { SpecialKey } from "../../utilities/Key";
+import { WakeLock } from "../../utilities/WakeLock";
 import { Attribution } from "../../components/attribution/Attribution";
 
 enum PlayerPageState {
@@ -76,6 +77,7 @@ export class PlayerPage extends React.Component<IPlayerPageProps, IPlayerPageSta
     hiddenAt: number = 0;
     toastTimeout: ReturnType<typeof setTimeout> | null = null;
     buzzerLockTimeout: ReturnType<typeof setTimeout> | null = null;
+    wakeLock: WakeLock = new WakeLock();
 
     constructor(props: IPlayerPageProps) {
         super(props);
@@ -149,6 +151,9 @@ export class PlayerPage extends React.Component<IPlayerPageProps, IPlayerPageSta
     componentDidMount = () => {
         window.addEventListener("keydown", this.handleKeyDown);
         document.addEventListener("visibilitychange", this.onVisibilityChange);
+
+        // Keep the phone/screen awake while on the buzzer so it doesn't sleep mid-game.
+        void this.wakeLock.enable();
 
         this.buildAndStartConnection(() => {
             if (window.location.hash.length == 7) {
@@ -501,6 +506,7 @@ export class PlayerPage extends React.Component<IPlayerPageProps, IPlayerPageSta
     componentWillUnmount() {
         window.removeEventListener("keydown", this.handleKeyDown);
         document.removeEventListener("visibilitychange", this.onVisibilityChange);
+        void this.wakeLock.disable();
         if (this.toastTimeout) clearTimeout(this.toastTimeout);
         if (this.buzzerLockTimeout) clearTimeout(this.buzzerLockTimeout);
         if (this.state.hubConnection) {

--- a/src/web/utilities/WakeLock.tsx
+++ b/src/web/utilities/WakeLock.tsx
@@ -1,0 +1,80 @@
+// Copyright (c) Jeff Steinbok. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+import { Logger } from "./Logger";
+
+/**
+ * Thin wrapper around the Screen Wake Lock API used to keep the display awake
+ * during a game (so the host board and player buzzer don't dim or sleep).
+ *
+ * The browser automatically releases a wake lock whenever the page becomes
+ * hidden (tab switch, phone lock, etc.), so this helper re-acquires the lock
+ * on visibilitychange while it is enabled. Supported on iOS Safari 16.4+ and
+ * evergreen desktop browsers; it degrades to a no-op where unavailable.
+ */
+export class WakeLock {
+    private sentinel: WakeLockSentinel | null = null;
+    private enabled: boolean = false;
+
+    private static get isSupported(): boolean {
+        return typeof navigator !== "undefined" && "wakeLock" in navigator;
+    }
+
+    /**
+     * Begin keeping the screen awake. Safe to call more than once. Must be
+     * triggered by (or shortly after) a user gesture on some platforms.
+     */
+    public enable = async (): Promise<void> => {
+        this.enabled = true;
+        document.addEventListener("visibilitychange", this.onVisibilityChange);
+        await this.acquire();
+    };
+
+    /** Stop keeping the screen awake and release any held lock. */
+    public disable = async (): Promise<void> => {
+        this.enabled = false;
+        document.removeEventListener("visibilitychange", this.onVisibilityChange);
+        await this.release();
+    };
+
+    private acquire = async (): Promise<void> => {
+        if (!this.enabled || !WakeLock.isSupported) {
+            return;
+        }
+        if (this.sentinel != null) {
+            return;
+        }
+        if (document.visibilityState !== "visible") {
+            return;
+        }
+        try {
+            this.sentinel = await navigator.wakeLock.request("screen");
+            this.sentinel.addEventListener("release", () => {
+                this.sentinel = null;
+            });
+            Logger.debug("WakeLock: acquired");
+        } catch (err) {
+            // Common on low battery or when not triggered by a user gesture.
+            Logger.debug("WakeLock: request failed", err);
+        }
+    };
+
+    private release = async (): Promise<void> => {
+        if (this.sentinel != null) {
+            try {
+                await this.sentinel.release();
+            } catch {
+                // Ignore — already released.
+            }
+            this.sentinel = null;
+            Logger.debug("WakeLock: released");
+        }
+    };
+
+    private onVisibilityChange = () => {
+        if (document.visibilityState === "visible") {
+            // The lock is dropped automatically when hidden; re-acquire it.
+            void this.acquire();
+        }
+    };
+}


### PR DESCRIPTION
Adds a `WakeLock` utility (Screen Wake Lock API) so the host board, the secondary/TV display, and the player buzzer keep the device screen awake during a game.

- Feature-detected; no-ops where unsupported.
- Re-acquires the lock on `visibilitychange` (browsers drop it when the page is hidden).
- Works on iOS Safari 16.4+, Android Chrome, and evergreen desktop browsers.

Wired into `PlayerPage`, `HostPage`, and `HostSecondaryPage` (enable on mount, disable on unmount).

Validation: lint + format clean, 176 frontend tests pass, prod build succeeds.