### PR TITLE
Catch reconnecting players up to game phase; ignore late buzzes on host

### DIFF
--- a/src/backend/Game.cs
+++ b/src/backend/Game.cs
@@ -60,6 +60,30 @@ namespace Jeffpardy
         bool gameStarted = false;
 
         /// <summary>
+        /// High-level phase the game is currently in. Tracked so a player who
+        /// (re)connects can be caught up to the right screen even if they missed
+        /// the broadcast that advanced the phase (e.g. reconnecting during the
+        /// transition into Final Jeffpardy).
+        /// </summary>
+        private enum GamePhase
+        {
+            Lobby,
+            Round,
+            FinalJeffpardyWager,
+            FinalJeffpardyClue,
+            FinalJeffpardyEnded,
+            GameOver,
+        }
+
+        GamePhase currentPhase = GamePhase.Lobby;
+
+        /// <summary>
+        /// The most recent scores broadcast for the game. Sent to a reconnecting
+        /// player so Final Jeffpardy max wagers and the end screen are correct.
+        /// </summary>
+        Dictionary<string, int> latestScores = new Dictionary<string, int>();
+
+        /// <summary>
         /// Team names that are locked in once the game starts. These persist even if all players disconnect.
         /// </summary>
         readonly HashSet<string> permanentTeamNames = new HashSet<string>();
@@ -217,6 +241,52 @@ namespace Jeffpardy
             }
 
             await this.SendUserListToAllClientsAsync();
+
+            // Catch the (re)connecting player up to the current phase in case they
+            // missed the broadcast that advanced it (e.g. they were disconnected
+            // during the transition into Final Jeffpardy and would otherwise be
+            // stuck on the buzzer screen).
+            await this.SendPhaseSyncAsync(connectionId);
+        }
+
+        /// <summary>
+        /// Replays the message(s) needed to move a single (re)connecting player's
+        /// UI to the game's current phase. Uses the same client events the normal
+        /// flow uses, so the player lands exactly where everyone else already is.
+        /// </summary>
+        private async Task SendPhaseSyncAsync(string connectionId)
+        {
+            GamePhase phase;
+            Dictionary<string, int> scores;
+            lock (_lock)
+            {
+                phase = this.currentPhase;
+                scores = new Dictionary<string, int>(this.latestScores);
+            }
+
+            var client = gameHubContext.Clients.Client(connectionId);
+            switch (phase)
+            {
+                case GamePhase.FinalJeffpardyWager:
+                    await client.SendAsync("startFinalJeffpardy", scores);
+                    break;
+                case GamePhase.FinalJeffpardyClue:
+                    await client.SendAsync("startFinalJeffpardy", scores);
+                    await client.SendAsync("showFinalJeffpardyClue");
+                    break;
+                case GamePhase.FinalJeffpardyEnded:
+                    await client.SendAsync("startFinalJeffpardy", scores);
+                    await client.SendAsync("showFinalJeffpardyClue");
+                    await client.SendAsync("endFinalJeffpardy");
+                    break;
+                case GamePhase.GameOver:
+                    await client.SendAsync("endGame", scores);
+                    break;
+                default:
+                    // Lobby / Round: the player's existing screen (front page,
+                    // lobby, or buzzer) is already correct; nothing to replay.
+                    break;
+            }
         }
 
         /// <summary>
@@ -411,6 +481,8 @@ namespace Jeffpardy
                     this.gameStarted = true;
                 }
 
+                this.currentPhase = GamePhase.Round;
+
                 // Lock in all current teams as permanent
                 foreach (var player in this.players.Values)
                 {
@@ -428,16 +500,30 @@ namespace Jeffpardy
 
         public async Task BroadcastScoresAsync(Dictionary<string, int> scores)
         {
+            lock (_lock)
+            {
+                this.latestScores = new Dictionary<string, int>(scores);
+            }
             await gameHubContext.Clients.Group(this.GameCode).SendAsync("broadcastScores", scores);
         }
 
         public async Task EndGameAsync(Dictionary<string, int> scores)
         {
+            lock (_lock)
+            {
+                this.currentPhase = GamePhase.GameOver;
+                this.latestScores = new Dictionary<string, int>(scores);
+            }
             await gameHubContext.Clients.Group(this.GameCode).SendAsync("endGame", scores);
         }
 
         public async Task StartFinalJeffpardyAsync(Dictionary<string, int> scores)
         {
+            lock (_lock)
+            {
+                this.currentPhase = GamePhase.FinalJeffpardyWager;
+                this.latestScores = new Dictionary<string, int>(scores);
+            }
             await gameHubContext.Clients.Group(this.GameCode).SendAsync("startFinalJeffpardy", scores);
         }
 
@@ -502,11 +588,19 @@ namespace Jeffpardy
 
         public async Task ShowFinalJeffpardyClueAsync()
         {
+            lock (_lock)
+            {
+                this.currentPhase = GamePhase.FinalJeffpardyClue;
+            }
             await gameHubContext.Clients.Group(this.GameCode).SendAsync("showFinalJeffpardyClue");
         }
 
         public async Task EndFinalJeffpardyAsync()
         {
+            lock (_lock)
+            {
+                this.currentPhase = GamePhase.FinalJeffpardyEnded;
+            }
             await gameHubContext.Clients.Group(this.GameCode).SendAsync("endFinalJeffpardy");
         }
 

--- a/src/backend/Jeffpardy.Tests/GameTests.cs
+++ b/src/backend/Jeffpardy.Tests/GameTests.cs
@@ -119,6 +119,61 @@ namespace Jeffpardy.Tests
         }
 
         [Fact]
+        public async Task ConnectPlayerAsync_ReconnectDuringFinal_ReplaysFinalJeffpardy()
+        {
+            var game = CreateGame();
+            await game.ConnectPlayerAsync("conn1", "TeamA", "Alice", "pid-alice");
+
+            // Host advances into Final Jeffpardy while the player is connected.
+            await game.StartFinalJeffpardyAsync(new Dictionary<string, int> { ["TeamA"] = 1200 });
+
+            _mockSingleClientProxy.Invocations.Clear();
+
+            // Player reconnects (new connection id, same durable player id). They
+            // must be caught up to Final Jeffpardy rather than left on the buzzer.
+            await game.ConnectPlayerAsync("conn1-new", "TeamA", "Alice", "pid-alice");
+
+            _mockSingleClientProxy.Verify(c => c.SendCoreAsync(
+                "startFinalJeffpardy",
+                It.IsAny<object?[]>(),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task ConnectPlayerAsync_ReconnectAfterGameOver_ReplaysEndGame()
+        {
+            var game = CreateGame();
+            await game.ConnectPlayerAsync("conn1", "TeamA", "Alice", "pid-alice");
+            await game.EndGameAsync(new Dictionary<string, int> { ["TeamA"] = 3400 });
+
+            _mockSingleClientProxy.Invocations.Clear();
+
+            await game.ConnectPlayerAsync("conn1-new", "TeamA", "Alice", "pid-alice");
+
+            _mockSingleClientProxy.Verify(c => c.SendCoreAsync(
+                "endGame",
+                It.IsAny<object?[]>(),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task ConnectPlayerAsync_DuringRound_DoesNotReplayPhase()
+        {
+            var game = CreateGame();
+            await game.StartRoundAsync(new GameRound());
+
+            _mockSingleClientProxy.Invocations.Clear();
+
+            await game.ConnectPlayerAsync("conn1", "TeamA", "Alice", "pid-alice");
+
+            // Round play needs no catch-up; the buzzer screen is already correct.
+            _mockSingleClientProxy.Verify(c => c.SendCoreAsync(
+                It.IsAny<string>(),
+                It.IsAny<object?[]>(),
+                It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
         public async Task RemoveUserAsync_RemovesPlayer_SendsUserList()
         {
             var game = CreateGame();

--- a/src/web/pages/hostPage/gameBoard/JeffpardyBoard.tsx
+++ b/src/web/pages/hostPage/gameBoard/JeffpardyBoard.tsx
@@ -403,6 +403,11 @@ export class JeffpardyBoard
                     finalJeffpardyTimerActive: false,
                 });
             } else {
+                // Stop honoring buzzes the instant the timer ends. The answer
+                // reveal below is still delayed so the "time's up" sound can
+                // play, but buzzerActive must flip now so a late in-flight buzz
+                // can't light up the host after the clue window closed.
+                this.props.jeffpardyHostController.buzzerActive = false;
                 this.timesUpSound.play();
                 // Delay showing the answer until after the sound plays
                 setTimeout(() => {


### PR DESCRIPTION
Fixes two gameplay bugs reported during a live game.

### 1. Stuck on buzzer after reconnecting into Final Jeffpardy
The player UI only advances to Final Jeffpardy (or game over) when it *receives* the broadcast. A player disconnected during that transition (e.g. phone locked) missed it and was stuck on the buzzer forever, because `connectPlayer` only re-sent the user list.

`Game` now tracks the current phase + latest scores, and `ConnectPlayerAsync` replays the appropriate message(s) to the (re)connecting player so they land on the correct screen. Uses the existing client events, so no new client handlers.

### 2. Late buzz lights up the host after the clue window closed
`buzzerActive` only flipped `false` 750ms after the timer visually ended (inside the delayed `buzzerTimeout` that waits for the "time's up" sound). A buzz arriving in that window still triggered the host highlight. Now `buzzerActive` flips the instant the timer ends, so the existing `assignBuzzedInUser` guard simply ignores the late receipt.

### Validation
- Backend: 167 tests pass (+3 new phase-sync/reconnect tests)
- Frontend: 176 tests pass, lint + format clean, prod build succeeds