### PR TITLE
Reset stale buzzer reaction time so it stops showing "Buzzed"

### DIFF
--- a/src/web/pages/playerPage/PlayerPage.tsx
+++ b/src/web/pages/playerPage/PlayerPage.tsx
@@ -229,6 +229,8 @@ export class PlayerPage extends React.Component<IPlayerPageProps, IPlayerPageSta
                 buzzerLocked: false,
                 buzzerEarlyClickLock: false,
                 buzzedInUser: null,
+                buzzedInUserReactionTime: 0,
+                reactionTime: 0,
                 isWinner: false,
                 isTeamWinner: false,
             });
@@ -241,6 +243,8 @@ export class PlayerPage extends React.Component<IPlayerPageProps, IPlayerPageSta
                 this.setState({ buzzed: false });
                 this.setState({ buzzerLocked: false });
                 this.setState({ buzzedInUser: null });
+                this.setState({ buzzedInUserReactionTime: 0 });
+                this.setState({ reactionTime: 0 });
             }
             this.setState({ buzzerActive: true });
         });


### PR DESCRIPTION
Fixes the player buzzer being stuck showing **Buzzed / 0 ms** on every clue.

The buzzer button shows "Buzzed" whenever `buzzedInUserReactionTime` is non-zero. That value (and the player's own `reactionTime`) is set by `assignWinner` but was **never cleared** — `resetBuzzer` and `activateBuzzer` reset every other buzzer flag except these two. So after the very first buzz of the game, the buzzer showed a stale "Buzzed" for the rest of the game.

Fix: clear `buzzedInUserReactionTime` and `reactionTime` in both the `resetBuzzer` and `activateBuzzer` handlers so each clue starts clean.

Pre-existing bug, unrelated to the recent reconnect/buzzer-guard work.

Validation: lint + format clean, 176 tests pass, prod build succeeds.